### PR TITLE
job106 調整1

### DIFF
--- a/data/project-c/functions/jobaction/106/items/gui/skill/page3.mcfunction
+++ b/data/project-c/functions/jobaction/106/items/gui/skill/page3.mcfunction
@@ -75,26 +75,26 @@ tag @s[tag=106_gui_item] remove 106_gui_item
 
 
 
-#tag @s[tag=!106_gui_item,nbt={Inventory:[{Slot:33b,tag:{106_gui_item:33,106_skill_page:3}}]}] add 106_gui_item
-#clear @s[tag=!106_gui_item] #project-c:neac/all{106_gui_item:33,106_skill_page:3}
-#execute if entity @s[tag=!106_gui_item,tag=!106_page_setup] at @s run playsound minecraft:entity.experience_orb.pickup master @s ~ ~ ~ 1 1.2
-#execute if entity @s[tag=!106_gui_item,tag=!106_page_setup] run tag @s add 106_skill_page_setup
-#execute if entity @s[tag=!106_gui_item,tag=!106_page_setup] run scoreboard players set @s counter_6 307
-#execute if entity @s if score @s counter_3 matches 7 run tag @s add 106_selecting
-#execute if entity @s if score @s counter_4 matches 7 run tag @s add 106_selecting
-#execute if entity @s if score @s counter_5 matches 7 run tag @s add 106_selecting
-#execute if entity @s[tag=!106_gui_item] run loot replace block 0 0 0 container.0 loot project-c:neac/106/skill/07
-#execute if entity @s[tag=!106_gui_item] run data modify block 0 0 0 Items[0].tag.106_skill_page set value 3
-#execute if entity @s[tag=!106_gui_item] run data modify block 0 0 0 Items[0].tag.106_gui_item set value 33
-#execute if entity @s[tag=!106_gui_item] run data remove block 0 0 0 Items[0].tag.106_skill
-#execute if entity @s[tag=!106_gui_item] run data remove block 0 0 0 Items[0].tag.106_skill_slot
-#execute if entity @s[tag=!106_gui_item,tag=106_selecting] if score @s counter_3 matches 7 run loot replace block 0 0 0 container.1 loot project-c:neac/106/skill/slot1_selecting_insert
-#execute if entity @s[tag=!106_gui_item,tag=106_selecting] if score @s counter_4 matches 7 run loot replace block 0 0 0 container.1 loot project-c:neac/106/skill/slot2_selecting_insert
-#execute if entity @s[tag=!106_gui_item,tag=106_selecting] if score @s counter_5 matches 7 run loot replace block 0 0 0 container.1 loot project-c:neac/106/skill/slot3_selecting_insert
-#execute if entity @s[tag=!106_gui_item,tag=106_selecting] run data modify block 0 0 0 Items[0].tag.display.Name set from block 0 0 0 Items[1].tag.display.Name
-#execute if entity @s[tag=!106_gui_item,tag=106_selecting] run data modify block 0 0 0 Items[0].tag.Enchantments set value [{}]
-#execute if entity @s[tag=!106_gui_item] run loot replace entity @s container.33 1 mine 0 0 0 air{inv_copy:1b}
-replaceitem entity @s[tag=106_page_setup] container.33 minecraft:air
+tag @s[tag=!106_gui_item,nbt={Inventory:[{Slot:33b,tag:{106_gui_item:33,106_skill_page:3}}]}] add 106_gui_item
+clear @s[tag=!106_gui_item] #project-c:neac/all{106_gui_item:33,106_skill_page:3}
+execute if entity @s[tag=!106_gui_item,tag=!106_page_setup] at @s run playsound minecraft:entity.experience_orb.pickup master @s ~ ~ ~ 1 1.2
+execute if entity @s[tag=!106_gui_item,tag=!106_page_setup] run tag @s add 106_skill_page_setup
+execute if entity @s[tag=!106_gui_item,tag=!106_page_setup] run scoreboard players set @s counter_6 311
+execute if entity @s if score @s counter_3 matches 11 run tag @s add 106_selecting
+execute if entity @s if score @s counter_4 matches 11 run tag @s add 106_selecting
+execute if entity @s if score @s counter_5 matches 11 run tag @s add 106_selecting
+execute if entity @s[tag=!106_gui_item] run loot replace block 0 0 0 container.0 loot project-c:neac/106/skill/11
+execute if entity @s[tag=!106_gui_item] run data modify block 0 0 0 Items[0].tag.106_skill_page set value 3
+execute if entity @s[tag=!106_gui_item] run data modify block 0 0 0 Items[0].tag.106_gui_item set value 33
+execute if entity @s[tag=!106_gui_item] run data remove block 0 0 0 Items[0].tag.106_skill
+execute if entity @s[tag=!106_gui_item] run data remove block 0 0 0 Items[0].tag.106_skill_slot
+execute if entity @s[tag=!106_gui_item,tag=106_selecting] if score @s counter_3 matches 11 run loot replace block 0 0 0 container.1 loot project-c:neac/106/skill/slot1_selecting_insert
+execute if entity @s[tag=!106_gui_item,tag=106_selecting] if score @s counter_4 matches 11 run loot replace block 0 0 0 container.1 loot project-c:neac/106/skill/slot2_selecting_insert
+execute if entity @s[tag=!106_gui_item,tag=106_selecting] if score @s counter_5 matches 11 run loot replace block 0 0 0 container.1 loot project-c:neac/106/skill/slot3_selecting_insert
+execute if entity @s[tag=!106_gui_item,tag=106_selecting] run data modify block 0 0 0 Items[0].tag.display.Name set from block 0 0 0 Items[1].tag.display.Name
+execute if entity @s[tag=!106_gui_item,tag=106_selecting] run data modify block 0 0 0 Items[0].tag.Enchantments set value [{}]
+execute if entity @s[tag=!106_gui_item] run loot replace entity @s container.33 1 mine 0 0 0 air{inv_copy:1b}
+#replaceitem entity @s[tag=106_page_setup] container.33 minecraft:air
 tag @s[tag=106_selecting] remove 106_selecting
 tag @s[tag=106_gui_item] remove 106_gui_item
 

--- a/data/project-c/functions/jobaction/106/items/loot_items.mcfunction
+++ b/data/project-c/functions/jobaction/106/items/loot_items.mcfunction
@@ -5,10 +5,6 @@ execute if score #106_slot_pos counter matches 1 run loot replace entity @s cont
 execute if score #106_slot_pos counter matches 2 run loot replace entity @s container.2 1 mine 0 0 0 air{inv_copy:1b}
 execute if score #106_slot_pos counter matches 3 run loot replace entity @s container.3 1 mine 0 0 0 air{inv_copy:1b}
 execute if score #106_slot_pos counter matches 4 run loot replace entity @s container.4 1 mine 0 0 0 air{inv_copy:1b}
-execute if score #106_slot_pos counter matches 5 run loot replace entity @s container.5 1 mine 0 0 0 air{inv_copy:1b}
-execute if score #106_slot_pos counter matches 6 run loot replace entity @s container.6 1 mine 0 0 0 air{inv_copy:1b}
-execute if score #106_slot_pos counter matches 7 run loot replace entity @s container.7 1 mine 0 0 0 air{inv_copy:1b}
-execute if score #106_slot_pos counter matches 8 run loot replace entity @s container.8 1 mine 0 0 0 air{inv_copy:1b}
 execute if score #106_slot_pos counter matches -106 run loot replace entity @s weapon.offhand 1 mine 0 0 0 air{inv_copy:1b}
 
 data remove block 0 0 0 Items[]

--- a/data/project-c/functions/jobaction/106/items/skill/01/proc1.mcfunction
+++ b/data/project-c/functions/jobaction/106/items/skill/01/proc1.mcfunction
@@ -6,8 +6,8 @@ execute anchored eyes run particle minecraft:sneeze ~ ~1 ~ 0.2 0.4 0.2 0.1 1 for
 
 
 
-execute if score @s 106-relieveD matches 0 run summon area_effect_cloud ~ ~1 ~ {Particle:"",Radius:0.1f,WaitTime:1,Duration:5,Age:4,Effects:[{Id:7b,Amplifier:0b,Duration:1,ShowIcon:0b},{Id:11b,Amplifier:2b,Duration:1,ShowIcon:0b}]}
-execute if score @s 106-relieveD matches 0 run effect give @s minecraft:wither 3 4 true
+execute if score @s 106-relieveD matches 0 run summon area_effect_cloud ~ ~1 ~ {Particle:"",Radius:0.3f,WaitTime:1,Duration:5,Age:4,Effects:[{Id:11b,Amplifier:2b,Duration:1,ShowIcon:0b},{Id:7b,Amplifier:0b,Duration:1,ShowIcon:0b}]}
+execute if score @s 106-relieveD matches 0 run effect give @s minecraft:wither 4 3 true
 execute if score @s 106-relieveD matches 0 anchored eyes run particle minecraft:damage_indicator ~ ~1 ~ 0.2 0.4 0.2 1 10 force
 execute if score @s 106-relieveD matches 0 run playsound minecraft:item.trident.riptide_3 master @a ~ ~ ~ 1 1.4
 execute if score @s deathCount matches 1.. run scoreboard players reset @s 106-relieveD

--- a/data/project-c/functions/jobaction/106/items/skill/02/use.mcfunction
+++ b/data/project-c/functions/jobaction/106/items/skill/02/use.mcfunction
@@ -5,7 +5,7 @@ execute if score @s counter_5 matches 2 run tag @s add skill3_use
 #===================================================================
 
 
-scoreboard players set #106_CT counter 400
+scoreboard players set #106_CT counter 200
 
 
 function project-c:jobaction/106/items/skill/bulk

--- a/data/project-c/functions/jobaction/106/items/skill/04/auxiliary/check.mcfunction
+++ b/data/project-c/functions/jobaction/106/items/skill/04/auxiliary/check.mcfunction
@@ -15,7 +15,7 @@ execute if entity @s[tag=using] if entity @e[tag=106_auxiliary_check,limit=1] ru
 execute if entity @s[tag=106_auxiliary_replace] run function project-c:jobaction/106/items/skill/04/auxiliary/set
 
 #Tagの削除
-execute if entity @e[type=minecraft:armor_stand,tag=sprink_arrow,tag=106_auxiliary_check,limit=1] as @e[type=minecraft:armor_stand,tag=sprink_arrow,tag=106_auxiliary_check] run tag @s remove 106_auxiliary_check
+execute if entity @e[type=minecraft:armor_stand,tag=106_sprink_arrow,tag=106_auxiliary_check,limit=1] as @e[type=minecraft:armor_stand,tag=106_sprink_arrow,tag=106_auxiliary_check] run tag @s remove 106_auxiliary_check
 execute if entity @s[tag=using] run tag @s remove using
 execute if entity @s[tag=106_auxiliary_replace] run tag @s remove 106_auxiliary_replace
 scoreboard players reset #106_slot_pos

--- a/data/project-c/functions/jobaction/106/items/skill/04/deployed.mcfunction
+++ b/data/project-c/functions/jobaction/106/items/skill/04/deployed.mcfunction
@@ -7,7 +7,7 @@ particle minecraft:splash ~ ~ ~ 0 0.4 0 0.1 10 force
 
 
 execute positioned 0.0 0.0 0.0 rotated ~ -35 positioned ^ ^ ^1.2 run summon area_effect_cloud ~ ~ ~ {Duration:1,Tags:["106_sprink_arrow_aec1"]}
-summon minecraft:arrow ~ ~ ~ {pickup:0b,Owner:[I;0,0,0,0],CustomName:'{"text":"スプリンクラーアロー"}',Tags:["106_sprink_arrow","106_sprink_arrow1","number_operation"],Color:-1,Motion:[0.0d,0.0d,0.0d]}
+summon minecraft:arrow ~ ~ ~ {pickup:0b,Owner:[I;0,0,0,0],CustomName:'{"text":"スプリンクラーアロー"}',Tags:["106_sprink_arrow","106_sprink_arrow1","number_operation"],Color:-1,Motion:[0.0d,0.0d,0.0d],damage:3.0d}
 
 execute if entity @e[tag=number_operation,tag=106_sprink_arrow1,limit=1] as @e[tag=number_operation,tag=106_sprink_arrow1] run data modify entity @s Motion set from entity @e[type=area_effect_cloud,tag=106_sprink_arrow_aec1,limit=1] Pos
 kill @e[type=area_effect_cloud,tag=106_sprink_arrow_aec1,limit=1]
@@ -16,7 +16,7 @@ execute if entity @e[tag=number_operation,tag=106_sprink_arrow1,limit=1] as @e[t
 
 
 execute positioned 0.0 0.24 0.0 rotated ~11 0 positioned ^ ^ ^1.2 run summon area_effect_cloud ~ ~ ~ {Duration:1,Tags:["106_sprink_arrow_aec2"]}
-summon minecraft:arrow ~ ~ ~ {pickup:0b,Owner:[I;0,0,0,0],CustomName:'{"text":"スプリンクラーアロー"}',Tags:["106_sprink_arrow","106_sprink_arrow2","number_operation","center"],Color:-1,Motion:[0.0d,0.0d,0.0d]}
+summon minecraft:arrow ~ ~ ~ {pickup:0b,Owner:[I;0,0,0,0],CustomName:'{"text":"スプリンクラーアロー"}',Tags:["106_sprink_arrow","106_sprink_arrow2","number_operation","center"],Color:-1,Motion:[0.0d,0.0d,0.0d],damage:3.0d}
 
 execute if entity @e[tag=number_operation,tag=106_sprink_arrow2,limit=1] as @e[tag=number_operation,tag=106_sprink_arrow2] run data modify entity @s Motion set from entity @e[type=area_effect_cloud,tag=106_sprink_arrow_aec2,limit=1] Pos
 kill @e[type=area_effect_cloud,tag=106_sprink_arrow_aec2,limit=1]
@@ -25,7 +25,7 @@ execute if entity @e[tag=number_operation,tag=106_sprink_arrow2,limit=1] as @e[t
 
 
 execute positioned 0.0 0.0 0.0 rotated ~ 35 positioned ^ ^ ^1.2 run summon area_effect_cloud ~ ~ ~ {Duration:1,Tags:["106_sprink_arrow_aec3"]}
-summon minecraft:arrow ~ ~ ~ {pickup:0b,Owner:[I;0,0,0,0],CustomName:'{"text":"スプリンクラーアロー"}',Tags:["106_sprink_arrow","106_sprink_arrow3","number_operation"],Color:-1,Motion:[0.0d,0.0d,0.0d]}
+summon minecraft:arrow ~ ~ ~ {pickup:0b,Owner:[I;0,0,0,0],CustomName:'{"text":"スプリンクラーアロー"}',Tags:["106_sprink_arrow","106_sprink_arrow3","number_operation"],Color:-1,Motion:[0.0d,0.0d,0.0d],damage:3.0d}
 
 execute if entity @e[tag=number_operation,tag=106_sprink_arrow3,limit=1] as @e[tag=number_operation,tag=106_sprink_arrow3] run data modify entity @s Motion set from entity @e[type=area_effect_cloud,tag=106_sprink_arrow_aec3,limit=1] Pos
 kill @e[type=area_effect_cloud,tag=106_sprink_arrow_aec3,limit=1]

--- a/data/project-c/functions/jobaction/106/items/skill/05/use.mcfunction
+++ b/data/project-c/functions/jobaction/106/items/skill/05/use.mcfunction
@@ -5,7 +5,7 @@ execute if score @s counter_5 matches 5 run tag @s add skill3_use
 #===================================================================
 
 
-scoreboard players set #106_CT counter 1200
+scoreboard players set #106_CT counter 600
 
 
 function project-c:jobaction/106/items/skill/bulk

--- a/data/project-c/functions/jobaction/106/items/skill/06/proc.mcfunction
+++ b/data/project-c/functions/jobaction/106/items/skill/06/proc.mcfunction
@@ -1,7 +1,7 @@
 #スキル6
 scoreboard players add @s counter 1
 
-execute if score @s counter matches 60 if entity @s[tag=106_wall_center] run playsound minecraft:item.shield.break master @a ~ ~ ~ 1 0.7
-execute if score @s counter matches 60 if entity @s[type=shulker] run particle block smooth_stone ~ ~0.5 ~ 0.2 0.2 0.2 0 2 force
-execute if score @s counter matches 60 run tp @s ~ ~-512 ~
-execute if score @s counter matches 60 run kill @s
+execute if score @s counter matches 100 if entity @s[tag=106_wall_center] run playsound minecraft:item.shield.break master @a ~ ~ ~ 1 0.7
+execute if score @s counter matches 100 if entity @s[type=shulker] run particle block smooth_stone ~ ~0.5 ~ 0.2 0.2 0.2 0 2 force
+execute if score @s counter matches 100 run tp @s ~ ~-512 ~
+execute if score @s counter matches 100 run kill @s

--- a/data/project-c/functions/jobaction/106/items/skill/08/hit.mcfunction
+++ b/data/project-c/functions/jobaction/106/items/skill/08/hit.mcfunction
@@ -1,0 +1,11 @@
+#スキル8
+execute as @a[tag=106_soul_curse_hit] if entity @s[gamemode=spectator] run tag @s remove 106_soul_curse_hit
+
+
+execute if entity @s[scores={counter_2=1..2}] as @e[tag=106_soul_curse_hit] at @s run summon area_effect_cloud ~ ~1 ~ {Particle:"",Radius:0.3f,WaitTime:1,Duration:5,Age:4,Effects:[{Id:11b,Amplifier:2b,Duration:1,ShowIcon:0b},{Id:7b,Amplifier:0b,Duration:1,ShowIcon:0b}]}
+execute if entity @s[scores={counter_2=3..4}] as @e[tag=106_soul_curse_hit] at @s run summon area_effect_cloud ~ ~1 ~ {Particle:"",Radius:0.3f,WaitTime:1,Duration:5,Age:4,Effects:[{Id:11b,Amplifier:1b,Duration:1,ShowIcon:0b},{Id:7b,Amplifier:0b,Duration:1,ShowIcon:0b}]}
+execute if entity @s[scores={counter_2=5..6}] as @e[tag=106_soul_curse_hit] at @s run summon area_effect_cloud ~ ~1 ~ {Particle:"",Radius:0.3f,WaitTime:1,Duration:5,Age:4,Effects:[{Id:11b,Amplifier:0b,Duration:1,ShowIcon:0b},{Id:7b,Amplifier:0b,Duration:1,ShowIcon:0b}]}
+execute if entity @s[scores={counter_2=7..}] as @e[tag=106_soul_curse_hit] at @s run summon area_effect_cloud ~ ~1 ~ {Particle:"",Radius:0.3f,WaitTime:1,Duration:5,Age:4,Effects:[{Id:7b,Amplifier:1b,Duration:1,ShowIcon:0b}]}
+
+
+tag @e[tag=106_soul_curse_hit] remove 106_soul_curse_hit

--- a/data/project-c/functions/jobaction/106/items/skill/08/proc.mcfunction
+++ b/data/project-c/functions/jobaction/106/items/skill/08/proc.mcfunction
@@ -3,9 +3,15 @@ playsound minecraft:entity.generic.eat master @a ~ ~1 ~ 0.1 0
 playsound minecraft:particle.soul_escape master @a ~ ~1 ~ 2 0
 particle block soul_sand ~ ~1 ~ 2 2 2 0.1 10 force
 
+scoreboard players add @s counter_1 1
+execute if entity @s[scores={counter_1=1}] run scoreboard players add @s counter_2 1
 
 execute if entity @s[tag=106-SoulCurse-Red] run particle dust 1 0 0 2 ~ ~1 ~ 0 0.2 0 0 1 force @a
 execute if entity @s[tag=106-SoulCurse-Blue] run particle dust 0 0 1 2 ~ ~1 ~ 0 0.2 0 0 1 force @a
 
-execute if entity @s[tag=106-SoulCurse-Red] positioned ~ ~1 ~ as @e[tag=Battle,team=!Red,distance=..5] run effect give @s wither 1 2 true
-execute if entity @s[tag=106-SoulCurse-Blue] positioned ~ ~1 ~ as @e[tag=Battle,team=!Blue,distance=..5] run effect give @s wither 1 2 true
+execute if entity @s[scores={counter_1=1},tag=106-SoulCurse-Red] positioned ~ ~1 ~ as @e[tag=Battle,team=!Red,distance=..5] run tag @s add 106_soul_curse_hit
+execute if entity @s[scores={counter_1=1},tag=106-SoulCurse-Blue] positioned ~ ~1 ~ as @e[tag=Battle,team=!Blue,distance=..5] run tag @s add 106_soul_curse_hit
+execute if entity @s[scores={counter_1=1}] if entity @e[tag=106_soul_curse_hit,limit=1] run function project-c:jobaction/106/items/skill/08/hit
+
+
+execute if entity @s[scores={counter_1=10..}] run scoreboard players set @s counter_1 0

--- a/data/project-c/functions/jobaction/106/items/skill/11/auxiliary/check.mcfunction
+++ b/data/project-c/functions/jobaction/106/items/skill/11/auxiliary/check.mcfunction
@@ -1,0 +1,22 @@
+#スキル11補助
+scoreboard players set #106_slot_pos counter -1000
+execute if score @s counter_3 matches 11 run scoreboard players set #106_slot_pos counter 1
+execute if score @s counter_4 matches 11 run scoreboard players set #106_slot_pos counter 2
+execute if score @s counter_5 matches 11 run scoreboard players set #106_slot_pos counter 3
+execute unless score #106_slot_pos counter matches -1000 run tag @s add using
+
+
+scoreboard players operation #106_playerNumber counter = @s playerNumber
+execute if entity @e[type=minecraft:creeper,tag=106_bomb,limit=1] as @e[type=minecraft:creeper,tag=106_bomb] if score @s playerNumber = #106_playerNumber counter run tag @s add 106_auxiliary_check
+
+execute if entity @s[tag=using] if entity @e[tag=106_auxiliary_check,limit=1] run tag @s add 106_auxiliary_replace
+
+
+execute if entity @s[tag=106_auxiliary_replace] run function project-c:jobaction/106/items/skill/11/auxiliary/set
+
+#Tagの削除
+execute if entity @e[type=minecraft:creeper,tag=106_bomb,tag=106_auxiliary_check,limit=1] as @e[type=minecraft:creeper,tag=106_bomb,tag=106_auxiliary_check] run tag @s remove 106_auxiliary_check
+execute if entity @s[tag=using] run tag @s remove using
+execute if entity @s[tag=106_auxiliary_replace] run tag @s remove 106_auxiliary_replace
+scoreboard players reset #106_slot_pos
+scoreboard players reset #106_playerNumber

--- a/data/project-c/functions/jobaction/106/items/skill/11/auxiliary/set.mcfunction
+++ b/data/project-c/functions/jobaction/106/items/skill/11/auxiliary/set.mcfunction
@@ -1,0 +1,21 @@
+#スキル4補助
+
+execute if score @s counter_3 matches 11 run tag @s add SkillDelay1
+execute if score @s counter_4 matches 11 run tag @s add SkillDelay2
+execute if score @s counter_5 matches 11 run tag @s add SkillDelay3
+
+
+execute if score @s counter_3 matches 11 run scoreboard players set #106_slot_pos counter 1
+execute if score @s counter_4 matches 11 run scoreboard players set #106_slot_pos counter 2
+execute if score @s counter_5 matches 11 run scoreboard players set #106_slot_pos counter 3
+loot replace block 0 0 0 container.0 loot project-c:neac/106/skill/auxiliary/11
+execute if score @s counter_3 matches 11 run data modify block 0 0 0 Items[0].tag.106_skill_slot set value 1
+execute if score @s counter_3 matches 11 run loot replace block 0 0 0 container.1 loot ex3:items/skill/slot1_number_insert
+execute if score @s counter_4 matches 11 run data modify block 0 0 0 Items[0].tag.106_skill_slot set value 2
+execute if score @s counter_4 matches 11 run loot replace block 0 0 0 container.1 loot ex3:items/skill/slot2_number_insert
+execute if score @s counter_5 matches 11 run data modify block 0 0 0 Items[0].tag.106_skill_slot set value 3
+execute if score @s counter_5 matches 11 run loot replace block 0 0 0 container.1 loot ex3:items/skill/slot3_number_insert
+
+data modify block 0 0 0 Items[0].tag.display.Lore prepend from block 0 0 0 Items[1].tag.display.Name
+
+function project-c:jobaction/106/items/loot_items

--- a/data/project-c/functions/jobaction/106/items/skill/11/auxiliary/use.mcfunction
+++ b/data/project-c/functions/jobaction/106/items/skill/11/auxiliary/use.mcfunction
@@ -1,0 +1,20 @@
+#起爆装置使用時処理
+
+scoreboard players operation #106_playerNumber counter = @s playerNumber
+execute as @e[type=minecraft:creeper,tag=106_bomb] if score @s playerNumber = #106_playerNumber counter run tag @s add 106_fuse_check
+
+execute if entity @e[type=minecraft:creeper,tag=106_bomb,tag=106_fuse_check] at @s run playsound minecraft:block.anvil.use master @a ~ ~ ~ 1 2
+execute unless entity @e[type=minecraft:creeper,tag=106_bomb,tag=106_fuse_check] at @s run playsound minecraft:entity.generic.burn master @a ~ ~ ~ 1 2
+
+execute at @s as @e[type=minecraft:creeper,tag=106_bomb,tag=106_fuse_check,sort=nearest,limit=1] run tag @s add 106_fuse
+
+execute at @e[type=minecraft:creeper,tag=106_bomb,tag=106_fuse,limit=1] run playsound minecraft:block.anvil.use master @a ~ ~ ~ 1 2
+
+execute as @e[type=minecraft:creeper,tag=106_bomb,tag=106_fuse,limit=1] at @s run function project-c:jobaction/106/items/skill/11/fuse
+
+
+execute if entity @e[type=minecraft:creeper,tag=106_bomb,tag=106_fuse_check,limit=1] as @e[type=minecraft:creeper,tag=106_bomb,tag=106_fuse_check] run tag @s remove 106_fuse_check
+
+
+scoreboard players reset #106_playerNumber
+

--- a/data/project-c/functions/jobaction/106/items/skill/11/bomb_receive.mcfunction
+++ b/data/project-c/functions/jobaction/106/items/skill/11/bomb_receive.mcfunction
@@ -1,0 +1,9 @@
+#モブがダメージ受けた処理
+
+scoreboard players set #106_H counter 10000
+execute store result score #106_health counter run data get entity @s Health 10
+scoreboard players operation #106_health counter -= #106_H counter
+scoreboard players operation @s counter_5 -= #106_health counter
+scoreboard players reset #106_H counter
+scoreboard players reset #106_health counter
+data modify entity @s Health set value 1000f

--- a/data/project-c/functions/jobaction/106/items/skill/11/fuse.mcfunction
+++ b/data/project-c/functions/jobaction/106/items/skill/11/fuse.mcfunction
@@ -1,0 +1,8 @@
+#スキル11
+
+function project-c:jobaction/106/items/skill/11/replace/check
+
+tag @s remove fuse
+effect clear @s
+data remove entity @s ActiveEffects
+data merge entity @s {Fuse:0s}

--- a/data/project-c/functions/jobaction/106/items/skill/11/fuse_timer.mcfunction
+++ b/data/project-c/functions/jobaction/106/items/skill/11/fuse_timer.mcfunction
@@ -1,0 +1,29 @@
+#スキル11
+scoreboard players add @s counter 1
+execute if entity @s[nbt=!{Health:1000f}] run function project-c:jobaction/106/items/skill/11/bomb_receive
+
+
+execute if score @s counter_6 matches 1.. run scoreboard players operation @s counter_5 -= @s counter_6
+execute if score @s counter_5 matches -2147483648..-1 run scoreboard players reset @s counter_5
+scoreboard players operation @s counter_6 += @s counter_5
+
+
+scoreboard players operation @s counter_3 -= @s counter_5
+
+execute if score @s counter_3 > @s counter_4 run scoreboard players operation @s counter_3 = @s counter_4
+
+
+execute if entity @s[scores={counter_6=1..}] if data entity @s {HurtTime:1s} run scoreboard players reset @s counter_6
+execute if entity @s[scores={counter_6=1..}] if data entity @s {HurtTime:0s} run scoreboard players reset @s counter_6
+
+#tellraw NeAc [{"text":"C:"},{"score":{"name":"@s","objective": "counter"}},{"text":"  HP:"},{"score":{"name":"@s","objective": "counter_3"}},{"text":"   maxHP:"},{"score":{"name":"@s","objective": "counter_4"}},{"text":"   ?1:"},{"score":{"name":"@s","objective": "counter_5"}},{"text":"   ?2:"},{"score":{"name":"@s","objective": "counter_6"}}]
+execute if entity @s[team=Red] run particle dust 1 0 0 1 ~ ~1 ~ 0.3 0.3 0.3 0 2 force @a
+execute if entity @s[team=Blue] run particle dust 0 0 1 1 ~ ~1 ~ 0.3 0.3 0.3 0 2 force @a
+
+execute store result entity @s Rotation[0] float 0.00001 run scoreboard players get @s counter_1
+execute store result entity @s Rotation[1] float 0.00001 run scoreboard players get @s counter_2
+function project-c:jobaction/106/fall_damage_nullification
+
+execute if score @s counter matches 200.. run function project-c:jobaction/106/items/skill/11/fuse
+
+execute if score @s counter_3 matches ..0 run function project-c:jobaction/106/items/skill/11/replace/check

--- a/data/project-c/functions/jobaction/106/items/skill/11/replace/check.mcfunction
+++ b/data/project-c/functions/jobaction/106/items/skill/11/replace/check.mcfunction
@@ -1,0 +1,7 @@
+#スキル11
+
+scoreboard players operation #106_playerNumber counter = @s playerNumber
+execute as @a if score @s playerNumber = #106_playerNumber counter run tag @s add 106_bomb_placer
+execute if entity @p[tag=106_bomb_placer] as @a[tag=106_bomb_placer] run function project-c:jobaction/106/items/skill/11/replace/execution
+execute if entity @p[tag=106_bomb_placer] run tag @a[tag=106_bomb_placer] remove 106_bomb_placer
+scoreboard players reset #106_playerNumber

--- a/data/project-c/functions/jobaction/106/items/skill/11/replace/execution.mcfunction
+++ b/data/project-c/functions/jobaction/106/items/skill/11/replace/execution.mcfunction
@@ -1,0 +1,18 @@
+#スキル11
+
+execute if entity @s[scores={counter_3=11}] run tag @s remove SkillDelay1
+execute if entity @s[scores={counter_3=11,CT1=..1199}] run clear @s #project-c:neac/all{106_auxiliary_skill:11b}
+execute if entity @s[scores={counter_3=11,CT1=..1199}] run function project-c:general/cooltimecounter
+
+execute if entity @s[scores={counter_4=11}] run tag @s remove SkillDelay2
+execute if entity @s[scores={counter_4=11,CT2=..1199}] run clear @s #project-c:neac/all{106_auxiliary_skill:11b}
+execute if entity @s[scores={counter_4=11,CT2=..1199}] run function project-c:general/cooltimecounter
+
+execute if entity @s[scores={counter_5=11}] run tag @s remove SkillDelay3
+execute if entity @s[scores={counter_5=11,CT3=..1199}] run clear @s #project-c:neac/all{106_auxiliary_skill:11b}
+execute if entity @s[scores={counter_5=11,CT3=..1199}] run function project-c:general/cooltimecounter
+
+
+execute if entity @s[scores={counter_3=11,CT1=1200..}] run function project-c:jobaction/106/items/skill/10/set
+execute if entity @s[scores={counter_4=11,CT2=1200..}] run function project-c:jobaction/106/items/skill/10/set
+execute if entity @s[scores={counter_5=11,CT3=1200..}] run function project-c:jobaction/106/items/skill/10/set

--- a/data/project-c/functions/jobaction/106/items/skill/11/set.mcfunction
+++ b/data/project-c/functions/jobaction/106/items/skill/11/set.mcfunction
@@ -1,0 +1,3 @@
+scoreboard players set #106_skill counter 11
+
+function project-c:jobaction/106/items/skill/slot_check

--- a/data/project-c/functions/jobaction/106/items/skill/11/use.mcfunction
+++ b/data/project-c/functions/jobaction/106/items/skill/11/use.mcfunction
@@ -1,0 +1,35 @@
+#スキル11
+execute if score @s counter_3 matches 11 run tag @s add skill1_use
+execute if score @s counter_4 matches 11 run tag @s add skill2_use
+execute if score @s counter_5 matches 11 run tag @s add skill3_use
+#===================================================================
+
+
+scoreboard players set #106_CT counter 400
+
+
+function project-c:jobaction/106/items/skill/bulk
+
+
+
+playsound minecraft:block.dispenser.dispense master @a ~ ~ ~ 1 1.2
+playsound minecraft:block.dispenser.dispense master @a ~ ~ ~ 1 1.2
+particle minecraft:block green_stained_glass ~ ~1 ~ 0 0 0 0.2 30
+summon minecraft:creeper ~ ~ ~ {CustomName:'{"text":"ボム"}',Tags:["106_bomb","number_operation","fall_damage_nullification"],ignited:1b,ExplosionRadius:2b,Fuse:10000s}
+
+attribute @e[tag=number_operation,limit=1] generic.movement_speed base set 0
+attribute @e[tag=number_operation,limit=1] generic.follow_range base set 0
+execute as @e[tag=number_operation,limit=1] store result score @s counter_1 run data get entity @s Rotation[0] 100000
+execute as @e[tag=number_operation,limit=1] store result score @s counter_2 run data get entity @s Rotation[1] 100000
+scoreboard players set @e[tag=number_operation,limit=1] counter_3 200
+scoreboard players set @e[tag=number_operation,limit=1] counter_4 200
+scoreboard players operation @e[tag=number_operation,limit=1] playerNumber = @s playerNumber
+scoreboard players operation @e[tag=number_operation,limit=1] playerNumber = @s playerNumber
+execute if entity @s[team=Red] run team join Red @e[tag=number_operation,limit=1]
+execute if entity @s[team=Blue] run team join Blue @e[tag=number_operation,limit=1]
+data merge entity @e[tag=number_operation,limit=1] {Health:1000f,Attributes:[{Name:"generic.max_health",Base:1000}]}
+tag @e[tag=number_operation,limit=1] remove number_operation
+
+
+
+function project-c:jobaction/106/items/skill/11/auxiliary/set

--- a/data/project-c/functions/jobaction/106/items/skill/repeat.mcfunction
+++ b/data/project-c/functions/jobaction/106/items/skill/repeat.mcfunction
@@ -46,4 +46,9 @@ execute if entity @e[type=minecraft:area_effect_cloud,tag=106_soul_curse,limit=1
 execute if entity @p[scores={jobNumber=106,counter_9=1..}] as @a[scores={jobNumber=106,counter_9=1..}] at @s run function project-c:jobaction/106/items/skill/09/proc
 
 
+#ボム
+execute if entity @e[type=minecraft:creeper,tag=106_bomb,limit=1] as @e[type=minecraft:creeper,tag=106_bomb] at @s run function project-c:jobaction/106/items/skill/11/fuse_timer
+
+
+
 execute if entity @p[tag=106_skill_no_drop] as @a[tag=106_skill_no_drop] run tag @s remove 106_skill_no_drop

--- a/data/project-c/functions/jobaction/106/items/skill/setup.mcfunction
+++ b/data/project-c/functions/jobaction/106/items/skill/setup.mcfunction
@@ -1,7 +1,10 @@
 tag @s remove 106_skill_setup
 
-
+execute if entity @s[tag=SkillDelay1] run tag @s remove SkillDelay1
+execute if entity @s[tag=SkillDelay2] run tag @s remove SkillDelay2
+execute if entity @s[tag=SkillDelay3] run tag @s remove SkillDelay3
 function project-c:jobaction/106/items/skill/04/auxiliary/check
+function project-c:jobaction/106/items/skill/11/auxiliary/check
 
 
 execute if entity @s[tag=!SkillReady1] at @s if score @s CT1 matches 1200.. run playsound minecraft:block.shulker_box.close master @s ~ ~ ~ 0.5 2 0.5
@@ -82,4 +85,11 @@ execute if score @s counter_3 matches 10 if score @s CT1 matches 1200.. run tag 
 execute if score @s counter_4 matches 10 if score @s CT2 matches 1200.. run tag @s add using
 execute if score @s counter_5 matches 10 if score @s CT3 matches 1200.. run tag @s add using
 execute if entity @s[tag=using] run function project-c:jobaction/106/items/skill/10/set
+tag @s[tag=using] remove using
+
+
+execute if score @s[tag=!SkillDelay1] counter_3 matches 11 if score @s CT1 matches 1200.. run tag @s add using
+execute if score @s[tag=!SkillDelay2] counter_4 matches 11 if score @s CT2 matches 1200.. run tag @s add using
+execute if score @s[tag=!SkillDelay3] counter_5 matches 11 if score @s CT3 matches 1200.. run tag @s add using
+execute if entity @s[tag=using] run function project-c:jobaction/106/items/skill/11/set
 tag @s[tag=using] remove using

--- a/data/project-c/functions/jobaction/106/items/skill/slot_check.mcfunction
+++ b/data/project-c/functions/jobaction/106/items/skill/slot_check.mcfunction
@@ -13,6 +13,7 @@ execute if score #106_skill counter matches 7 run loot replace block 0 0 0 conta
 execute if score #106_skill counter matches 8 run loot replace block 0 0 0 container.0 loot project-c:neac/106/skill/08
 execute if score #106_skill counter matches 9 run loot replace block 0 0 0 container.0 loot project-c:neac/106/skill/09
 execute if score #106_skill counter matches 10 run loot replace block 0 0 0 container.0 loot project-c:neac/106/skill/10
+execute if score #106_skill counter matches 11 run loot replace block 0 0 0 container.0 loot project-c:neac/106/skill/11
 
 
 execute if score #106_slot_pos counter matches 1 if score @s CT1 matches 1200.. run data modify block 0 0 0 Items[0].tag.skill_slot set value 1

--- a/data/project-c/functions/jobaction/106/items/skill/use_check.mcfunction
+++ b/data/project-c/functions/jobaction/106/items/skill/use_check.mcfunction
@@ -55,7 +55,7 @@ execute if entity @s[nbt={SelectedItem:{tag:{106_auxiliary_skill:4b}}},scores={u
 
 
 #偵察
-execute if entity @s[scores={jump=1..}] if score #106_has_skill counter matches 5 if score #106_has_skill_ct counter matches 1200.. run function project-c:jobaction/106/items/skill/05/use
+execute if entity @s[scores={jump=1..},tag=Battle] if score #106_has_skill counter matches 5 if score #106_has_skill_ct counter matches 1200.. run function project-c:jobaction/106/items/skill/05/use
 
 
 
@@ -93,7 +93,7 @@ execute if entity @s[scores={counter_5=9,CT3=1200..}] run function project-c:job
 
 
 #ショートテレポート
-execute if entity @s[scores={jump=1..}] if score #106_has_skill counter matches 10 if score #106_has_skill_ct counter matches 1200.. run function project-c:jobaction/106/items/skill/10/use
+execute if entity @s[scores={jump=1..},tag=Battle] if score #106_has_skill counter matches 10 if score #106_has_skill_ct counter matches 1200.. run function project-c:jobaction/106/items/skill/10/use
 #パーティクル
 execute if score #106_has_skill counter matches 10 if score #106_has_skill_ct counter matches 1200.. run function project-c:jobaction/106/items/skill/10/particle_call
 
@@ -101,6 +101,10 @@ execute if score #106_has_skill counter matches 10 if score #106_has_skill_ct co
 
 
 
+#ボム
+execute if entity @s[scores={sneak=1..}] if score #106_has_skill counter matches 11 if score #106_has_skill_ct counter matches 1200.. run function project-c:jobaction/106/items/skill/11/use
+#起爆装置
+execute if entity @s[nbt={SelectedItem:{tag:{106_auxiliary_skill:11b}}},scores={useCarrotStick=1..}] run function project-c:jobaction/106/items/skill/11/auxiliary/use
 
 
 

--- a/data/project-c/functions/jobaction/106/main.mcfunction
+++ b/data/project-c/functions/jobaction/106/main.mcfunction
@@ -26,7 +26,7 @@ execute if entity @s[advancements={project-c:neac/inventory_changed=true}] run f
 
 
 
-function project-c:jobaction/106/items/skill/use_check
+execute if entity @s[gamemode=!spectator] run function project-c:jobaction/106/items/skill/use_check
 
 
 execute if entity @s[scores={drop2=1..}] run function project-c:jobaction/106/drop

--- a/data/project-c/functions/jobaction/106/replaceitem/0.mcfunction
+++ b/data/project-c/functions/jobaction/106/replaceitem/0.mcfunction
@@ -1,4 +1,8 @@
 
 execute if entity @s[scores={counter_1=..0}] run function project-c:jobaction/106/change
+execute store result score #106_item_check counter run clear @s #project-c:neac/all 0
 
+execute if score #106_item_check counter matches ..19 run tag @s add 106_change_setup
+execute if score #106_item_check counter matches ..19 run function project-c:jobaction/106/change_keep
+scoreboard players reset #106_item_check
 scoreboard players reset @s drop

--- a/data/project-c/loot_tables/neac/106/skill/02.json
+++ b/data/project-c/loot_tables/neac/106/skill/02.json
@@ -19,7 +19,7 @@
               "lore": [
                 {"text": "タイプ：パッシブ","italic": false,"color": "green"},
                 {"text": "トリガ：ドロップ","italic": false,"color": "yellow"},
-                {"text": "クールタイム：20秒","italic": false,"color": "aqua"},
+                {"text": "クールタイム：10秒","italic": false,"color": "aqua"},
                 {"text": "近距離の敵の視点を真上にする","italic": false,"color": "dark_purple"}
               ]
             },

--- a/data/project-c/loot_tables/neac/106/skill/05.json
+++ b/data/project-c/loot_tables/neac/106/skill/05.json
@@ -19,7 +19,7 @@
               "lore": [
                 {"text": "タイプ：アクティブ","italic": false,"color": "green"},
                 {"text": "トリガ：ジャンプ","italic": false,"color": "yellow"},
-                {"text": "クールタイム：1分","italic": false,"color": "aqua"},
+                {"text": "クールタイム：30秒","italic": false,"color": "aqua"},
                 {"text": "スペクテイターとなり、周囲の状況を観察する","italic": false,"color": "dark_purple"},
                 {"text": "発動場所にはダミーが設置され、","italic": false,"color": "dark_purple"},
                 {"text": "真下を向く・20秒経過する・ダミーが攻撃される","italic": false,"color": "dark_purple"},

--- a/data/project-c/loot_tables/neac/106/skill/11.json
+++ b/data/project-c/loot_tables/neac/106/skill/11.json
@@ -6,12 +6,12 @@
       "entries": [
         {
           "type": "minecraft:item",
-          "name": "minecraft:smooth_stone",
+          "name": "minecraft:tnt",
           "functions": [
             {
               "function": "minecraft:set_name",
               "name": [
-                {"text": "ウォール","italic": false,"color": "white"}
+                {"text": "ボム","italic": false,"color": "white"}
               ]
             },
             {
@@ -19,14 +19,13 @@
               "lore": [
                 {"text": "タイプ：アクティブ","italic": false,"color": "green"},
                 {"text": "トリガ：スニーク","italic": false,"color": "yellow"},
-                {"text": "クールタイム：15秒","italic": false,"color": "aqua"},
-                {"text": "前方に破壊不能な5x5の壁を生成する","italic": false,"color": "dark_purple"},
-                {"text": "壁は設置後5秒で消滅する","italic": false,"color": "dark_purple"}
+                {"text": "クールタイム：20秒","italic": false,"color": "aqua"},
+                {"text": "ボムを設置する","italic": false,"color": "dark_purple"}
               ]
             },
             {
               "function": "minecraft:set_nbt",
-              "tag": "{HideFlags:63,106_skill:6,106_skill_slot:0}"
+              "tag": "{HideFlags:63,106_skill:11,106_skill_slot:0}"
             }
           ]
         }

--- a/data/project-c/loot_tables/neac/106/skill/auxiliary/11.json
+++ b/data/project-c/loot_tables/neac/106/skill/auxiliary/11.json
@@ -6,27 +6,25 @@
       "entries": [
         {
           "type": "minecraft:item",
-          "name": "minecraft:smooth_stone",
+          "name": "minecraft:carrot_on_a_stick",
           "functions": [
             {
               "function": "minecraft:set_name",
               "name": [
-                {"text": "ウォール","italic": false,"color": "white"}
+                {"text": "起爆装置","italic": false,"color": "white"}
               ]
             },
             {
               "function": "minecraft:set_lore",
               "lore": [
                 {"text": "タイプ：アクティブ","italic": false,"color": "green"},
-                {"text": "トリガ：スニーク","italic": false,"color": "yellow"},
-                {"text": "クールタイム：15秒","italic": false,"color": "aqua"},
-                {"text": "前方に破壊不能な5x5の壁を生成する","italic": false,"color": "dark_purple"},
-                {"text": "壁は設置後5秒で消滅する","italic": false,"color": "dark_purple"}
+                {"text": "トリガ：ライトクリック","italic": false,"color": "yellow"},
+                {"text": "自身が設置したボムを起爆する","italic": false,"color": "dark_purple"}
               ]
             },
             {
               "function": "minecraft:set_nbt",
-              "tag": "{HideFlags:63,106_skill:6,106_skill_slot:0}"
+              "tag": "{HideFlags:63,106_auxiliary_skill:11b,106_skill_slot:0}"
             }
           ]
         }


### PR DESCRIPTION
1. ゲーム終了後、ロビーに帰ってきたときにインベントリGUIに発生する問題の修正
2. スキルにボムを追加
```markdown
* ボム
タイプ：アクティブ
トリガ：スニーク
クールタイム：20秒
ボムを設置する
```
3. バランス調整
```markdown
* レリーヴ(アタック)
> ウィザー効果延長(1,2ダメージ程度増加)

* アロスプ
> 矢のダメージ増加(3→4)

* トリック
> CT減少(20秒→10秒)

* 偵察
> CT減少(60秒→30秒)

* ウォール
> 持続時間延長(3秒→5秒)

* 魂の呼び声
> ダメージ増加(本家に寄せる)
```
4. ゲーム開始前、スペクテイターで発動でスキルが発動できる問題の修正
```markdown
* ゲーム開始前
ショーテレ
偵察

* スペクテイター
全て
```