### PR TITLE
一旦完了

### DIFF
--- a/data/project-c/functions/jobaction/023/skill/2/3-3pa-.mcfunction
+++ b/data/project-c/functions/jobaction/023/skill/2/3-3pa-.mcfunction
@@ -1,0 +1,12 @@
+scoreboard players add @s subcounter 1
+tp @s ^ ^ ^1.4
+particle flame ~ ~ ~ 0.05 0.05 0.05 0.2 3 normal @a
+particle flame ~ ~ ~ 0.3 0.3 0.3 0.015 1 force @a
+execute if entity @s[scores={subcounter=3..}] run particle lava ~ ~ ~ 0.2 0.2 0.2 0.4 1 normal @a
+execute if entity @s[team=RedDummy] at @e[tag=Battle,team=!Red,distance=..2] run summon arrow ~ ~3 ~ {CustomName:"{\"text\":\"Flame Razer\",\"color\":\"red\"}",Motion:[0.0d,-1.0d,0.0d],pickup:0,damage:4.0d,life:1200s,Fire:100s}
+execute if entity @s[team=BlueDummy] at @e[tag=Battle,team=!Blue,distance=..2] run summon arrow ~ ~3 ~ {CustomName:"{\"text\":\"Flame Razer\",\"color\":\"red\"}",Motion:[0.0d,-1.0d,0.0d],pickup:0,damage:4.0d,life:1200s,Fire:100s}
+
+
+scoreboard players set @s[scores={subcounter=3..}] subcounter 0
+execute unless block ^ ^0.5 ^0.7 #project-c:wancomatter/like_air run kill @s
+execute unless block ^ ^0.5 ^1.4 #project-c:wancomatter/like_air run kill @s

--- a/data/project-c/functions/jobaction/023/skill/2/3-3pa.mcfunction
+++ b/data/project-c/functions/jobaction/023/skill/2/3-3pa.mcfunction
@@ -1,19 +1,6 @@
 scoreboard players add @s counter 1
-scoreboard players add @s subcounter 1
-execute unless block ^ ^ ^1.5 air run kill @s
-execute unless block ^ ^ ^3 air run kill @s
-execute if entity @s[scores={counter=40..}] run tp @s ^ ^ ^1.5
-particle flame ~ ~ ~ 0.05 0.05 0.05 0.2 3 normal @a
-particle flame ~ ~ ~ 0.3 0.3 0.3 0.015 1 force @a
-execute if entity @s[scores={subcounter=3..}] run particle lava ~ ~ ~ 0.2 0.2 0.2 0.4 1 normal @a
-execute if entity @s[team=RedDummy] at @e[tag=Battle,team=!Red,distance=..2] run summon arrow ~ ~3 ~ {CustomName:"{\"text\":\"Flame Razer\",\"color\":\"red\"}",Motion:[0.0d,-1.0d,0.0d],pickup:0,damage:4.0d,life:1200s,Fire:100s}
-execute if entity @s[team=BlueDummy] at @e[tag=Battle,team=!Blue,distance=..2] run summon arrow ~ ~3 ~ {CustomName:"{\"text\":\"Flame Razer\",\"color\":\"red\"}",Motion:[0.0d,-1.0d,0.0d],pickup:0,damage:4.0d,life:1200s,Fire:100s}
-execute if entity @s[scores={counter=30..}] run tp @s ^ ^ ^1.5
-particle flame ~ ~ ~ 0.05 0.05 0.05 0.2 3 normal @a
-particle flame ~ ~ ~ 0.3 0.3 0.3 0.05 1 force @a
-execute if entity @s[scores={subcounter=3..}] run particle lava ~ ~ ~ 0.2 0.2 0.2 0.4 1 normal @a
-execute if entity @s[team=RedDummy] at @e[tag=Battle,team=!Red,distance=..2] run summon arrow ~ ~3 ~ {CustomName:"{\"text\":\"Flame Razer\",\"color\":\"red\"}",Motion:[0.0d,-1.0d,0.0d],pickup:0,damage:4.0d,life:1200s,Fire:100s}
-execute if entity @s[team=BlueDummy] at @e[tag=Battle,team=!Blue,distance=..2] run summon arrow ~ ~3 ~ {CustomName:"{\"text\":\"Flame Razer\",\"color\":\"red\"}",Motion:[0.0d,-1.0d,0.0d],pickup:0,damage:4.0d,life:1200s,Fire:100s}
+execute if entity @s[scores={counter=40..}] at @s run function project-c:jobaction/023/skill/2/3-3pa-
+execute if entity @s[scores={counter=30..}] at @s run function project-c:jobaction/023/skill/2/3-3pa-
 
 scoreboard players set @s[scores={subcounter=3..}] subcounter 0
 kill @s[scores={counter=100..}]

--- a/data/project-c/functions/jobaction/026/replaceitem/1.mcfunction
+++ b/data/project-c/functions/jobaction/026/replaceitem/1.mcfunction
@@ -1,3 +1,3 @@
-replaceitem entity @s hotbar.1 minecraft:heart_of_the_sea{display:{Name:"{\"text\":\"水神様の加護\"}",Lore:["{\"text\":\"§e発動:スニーク\"}","{\"text\":\"§7その場に水の結界を設置。\"}","{\"text\":\"§f周囲の味方へ再生の加護を与える。\"}","{\"text\":\"§aCT:30\"}"]}} 1
+replaceitem entity @s hotbar.1 minecraft:heart_of_the_sea{display:{Name:"{\"text\":\"水神様の加護\"}",Lore:["{\"text\":\"§e発動:スニーク\"}","{\"text\":\"§7その場に水の結界を設置。\"}","{\"text\":\"§f周囲の味方へ体力再生とCT加速の加護を与える。\"}","{\"text\":\"§aCT:30\"}"]}} 1
 playsound minecraft:block.shulker_box.close master @s ~ ~ ~ 0.5 2 0.5
 tag @s add SkillReady1

--- a/data/project-c/functions/jobaction/026/skill/1/1.mcfunction
+++ b/data/project-c/functions/jobaction/026/skill/1/1.mcfunction
@@ -1,26 +1,14 @@
 scoreboard players add @s counter 1
-execute if entity @s[scores={counter=60..},tag=026-water-R] run effect give @e[team=Red,distance=..5,tag=Battle] minecraft:regeneration 2 2 false
-execute if entity @s[scores={counter=60..},tag=026-water-R] run effect give @e[team=Red,distance=..5,tag=Battle] minecraft:conduit_power 3 0 false
-execute if entity @s[scores={counter=60..},tag=026-water-B] run effect give @e[team=Blue,distance=..5,tag=Battle] minecraft:regeneration 2 2 false
-execute if entity @s[scores={counter=60..},tag=026-water-B] run effect give @e[team=Blue,distance=..5,tag=Battle] minecraft:conduit_power 3 0 false
-execute if entity @s[scores={counter=60..}] run particle minecraft:rain ~ ~3 ~ 2 1 2 1 120 normal @a
-execute if entity @s[scores={counter=60..}] run particle minecraft:rain ~ ~3 ~ 2 1 2 1 30 force @a
-execute if entity @s[scores={counter=60..}] run particle minecraft:end_rod ~ ~ ~ 0 0 0 0.2 80 normal @a
-execute if entity @s[scores={counter=60..}] run playsound minecraft:entity.dolphin.swim master @a ~ ~ ~ 1 2
-execute if entity @s[scores={counter=60..}] run playsound minecraft:entity.dolphin.swim master @a ~ ~ ~ 1 2
-execute if entity @s[scores={counter=60..}] run playsound minecraft:entity.player.splash.high_speed master @a ~ ~ ~ 1 1
-execute if entity @s[scores={counter=60..}] run playsound minecraft:ambient.underwater.enter master @a ~ ~ ~ 1 1
-execute if entity @s[scores={counter=60..}] run scoreboard players add @s subcounter 1
-execute if entity @s[scores={counter=60..}] run scoreboard players set @s counter -1
-execute if entity @s[scores={subcounter=6..}] run kill @s
+execute if entity @s[scores={counter=35..}] run function project-c:jobaction/026/skill/1/2
+execute if entity @s[scores={subcounter=9..}] run kill @s
 particle minecraft:fishing ~ ~ ~ 3 3 3 0 12 normal @a
 particle minecraft:fishing ~ ~ ~ 3 3 3 0 3 force @a
-execute facing ^1 ^ ^ run particle minecraft:dust 0 0 1 1 ^ ^ ^5 0 0 0 0 1
-execute facing ^1 ^ ^1 run particle minecraft:dust 0 0 1 1 ^ ^ ^5 0 0 0 0 1
-execute facing ^ ^ ^1 run particle minecraft:dust 0 0 1 1 ^ ^ ^5 0 0 0 0 1
-execute facing ^-1 ^ ^1 run particle minecraft:dust 0 0 1 1 ^ ^ ^5 0 0 0 0 1
-execute facing ^-1 ^ ^ run particle minecraft:dust 0 0 1 1 ^ ^ ^5 0 0 0 0 1
-execute facing ^-1 ^ ^-1 run particle minecraft:dust 0 0 1 1 ^ ^ ^5 0 0 0 0 1
-execute facing ^ ^ ^-1 run particle minecraft:dust 0 0 1 1 ^ ^ ^5 0 0 0 0 1
-execute facing ^1 ^ ^-1 run particle minecraft:dust 0 0 1 1 ^ ^ ^5 0 0 0 0 1
+execute facing ^1 ^ ^ run particle minecraft:dust 0 0 1 1 ^ ^ ^8 0 0 0 0 1
+execute facing ^1 ^ ^1 run particle minecraft:dust 0 0 1 1 ^ ^ ^8 0 0 0 0 1
+execute facing ^ ^ ^1 run particle minecraft:dust 0 0 1 1 ^ ^ ^8 0 0 0 0 1
+execute facing ^-1 ^ ^1 run particle minecraft:dust 0 0 1 1 ^ ^ ^8 0 0 0 0 1
+execute facing ^-1 ^ ^ run particle minecraft:dust 0 0 1 1 ^ ^ ^8 0 0 0 0 1
+execute facing ^-1 ^ ^-1 run particle minecraft:dust 0 0 1 1 ^ ^ ^8 0 0 0 0 1
+execute facing ^ ^ ^-1 run particle minecraft:dust 0 0 1 1 ^ ^ ^8 0 0 0 0 1
+execute facing ^1 ^ ^-1 run particle minecraft:dust 0 0 1 1 ^ ^ ^8 0 0 0 0 1
 tp @s ~ ~ ~ ~3 ~

--- a/data/project-c/functions/jobaction/026/skill/1/2.mcfunction
+++ b/data/project-c/functions/jobaction/026/skill/1/2.mcfunction
@@ -1,0 +1,17 @@
+execute if entity @s[tag=026-water-R] run tag @e[team=Red,distance=..8,tag=Battle] add 026regene
+execute if entity @s[tag=026-water-B] run tag @e[team=Blue,distance=..8,tag=Battle] add 026regene
+execute if entity @e[tag=026regene,limit=1] at @e[tag=026regene] run summon area_effect_cloud ~ ~0.2 ~ {Particle:"splash",Duration:5,Age:4,WaitTime:1,Radius:0.9f,Effects:[{Id:29b,Amplifier:0b,Duration:35},{Id:6b,Amplifier:0b,Duration:1}]}
+execute if entity @e[tag=026regene,limit=1] run scoreboard players add @e[tag=026regene] CT1 20
+execute if entity @e[tag=026regene,limit=1] run scoreboard players add @e[tag=026regene] CT2 20
+execute if entity @e[tag=026regene,limit=1] run scoreboard players add @e[tag=026regene] CT3 20
+execute if entity @e[tag=026regene,limit=1] run tag @e[tag=026regene] remove 026regene
+particle minecraft:rain ~ ~3 ~ 3 1 3 1 200 normal @a
+particle minecraft:rain ~ ~3 ~ 3 1 3 1 50 force @a
+particle minecraft:end_rod ~ ~ ~ 0 0 0 0.4 120 normal @a
+particle minecraft:end_rod ~ ~ ~ 0 0 0 0.4 30 force @a
+playsound minecraft:entity.dolphin.swim master @a ~ ~ ~ 1 2
+playsound minecraft:entity.dolphin.swim master @a ~ ~ ~ 1 2
+playsound minecraft:entity.player.splash.high_speed master @a ~ ~ ~ 1 1
+playsound minecraft:ambient.underwater.enter master @a ~ ~ ~ 1 1
+scoreboard players add @s subcounter 1
+scoreboard players set @s counter -1

--- a/data/project-c/functions/jobaction/026/skill/2/0g.mcfunction
+++ b/data/project-c/functions/jobaction/026/skill/2/0g.mcfunction
@@ -1,4 +1,4 @@
-scoreboard players set @s CT2 1140
+scoreboard players set @s CT2 1190
 scoreboard players reset @s drop
 
 #三角関数周りの測定

--- a/data/project-c/functions/jobaction/026/skill/3/0.mcfunction
+++ b/data/project-c/functions/jobaction/026/skill/3/0.mcfunction
@@ -3,7 +3,7 @@ scoreboard players set @s drop 0
 clear @s iron_axe{display:{Name:"{\"text\":\"銀の斧\",\"color\":\"gray\",\"underlined\":true,\"italic\":false}"}}
 execute at @e[tag=026-water] if score @e[tag=026-water,distance=..0.01,sort=nearest,limit=1] playerNumber = @s playerNumber run clear @s golden_axe{display:{Name:"{\"text\":\"金の斧\",\"color\":\"gold\",\"underlined\":true,\"italic\":false}"}}
 
-replaceitem entity @s hotbar.0 minecraft:stone_axe{display:{Name:"\"古びた斧\"",Lore:["{\"text\":\"§5木こりの仕事用の斧。\"}","{\"text\":\"§d年季が入っている。\"}","{\"text\":\"\"}","{\"text\":\"§7利き手に持ったとき:\"}","{\"text\":\"§2 攻撃速度 0.8\"}","{\"text\":\"§2 攻撃力 8\"}"]},AttributeModifiers:[{Name:"HaruEditor",UUID:[I;-1637044811,653807115,-1588747286,325763061],Operation:0,AttributeName:"generic.attack_damage",Amount:7d,Slot:"mainhand"},{Name:"HaruEditor",UUID:[I;-1637044811,653807115,-1588747286,325763061],Operation:0,AttributeName:"generic.attack_speed",Amount:-3.2d,Slot:"mainhand"}],Enchantments:[{id:efficiency,lvl:2s}],Unbreakable:1b,HideFlags:2}
+function project-c:jobaction/026/replaceitem/0
 
 playsound minecraft:item.trident.thunder player @a ~ ~ ~ 1.5 2
 particle minecraft:explosion ~ ~ ~ 0.8 0.8 0.8 1 80 normal @a

--- a/data/project-c/functions/jobaction/031/main.mcfunction
+++ b/data/project-c/functions/jobaction/031/main.mcfunction
@@ -12,10 +12,7 @@ execute if entity @s[scores={CT1=1200..},tag=!SkillReady1] run function project-
 execute if entity @s[scores={CT2=1200..},tag=!SkillReady2] run function project-c:jobaction/031/replaceitem/2
 execute if entity @s[scores={CT3=1200..},tag=!SkillReady3] run function project-c:jobaction/031/replaceitem/3
 
-execute if entity @a[tag=031-0tDeath] as @a[tag=031-0tDeath,nbt={Health:0.0f}] run function project-c:jobaction/031/skill/0/2
-execute if entity @a[tag=031-0tDeath1] run tag @a[tag=031-0tDeath1] remove 031-0tDeath
-execute if entity @a[tag=031-0tDeath1] run tag @a[tag=031-0tDeath1] remove 031-0tDeath1
-execute if entity @a[tag=031-0tDeath] run tag @a[tag=031-0tDeath] add 031-0tDeath1
+execute if entity @e[tag=031blood_blade_check,limit=1] as @e[tag=031blood_blade_check,nbt={Age:3}] run function project-c:jobaction/031/skill/0/check
 
 execute if entity @s[nbt={SelectedItem:{tag:{display:{Name:"{\"text\":\"Short Flight\",\"italic\":false,\"color\":\"aqua\"}"}}}},scores={CT1=1200..,useCarrotStick=1..,subcounter=2..},tag=SkillReady1,gamemode=!spectator] at @s anchored feet if block ^ ^ ^1 air anchored eyes if block ^ ^ ^1 air anchored feet run function project-c:jobaction/031/skill/1/0
 execute if entity @s[nbt={SelectedItem:{tag:{display:{Name:"{\"text\":\"Short Flight\",\"italic\":false,\"color\":\"aqua\"}"}}}},scores={CT1=1200..,subcounter=2..},tag=SkillReady1,gamemode=!spectator] at @s anchored eyes run particle minecraft:dust 0.33 0 0 0.4 ^ ^ ^2 0.01 0.01 0.01 1 8 normal @s
@@ -31,7 +28,7 @@ execute if entity @s[nbt={SelectedItem:{tag:{display:{Name:"{\"text\":\"Bloody F
 execute if entity @s[nbt={SelectedItem:{tag:{031S3:1b}}},scores={drop2=1..},gamemode=!spectator] unless entity @s[tag=!SkillReady2,tag=!SkillReady3] run function project-c:jobaction/031/skill/3/-
 
 execute if entity @s[nbt={SelectedItem:{tag:{display:{Name:"{\"text\":\"Blood Blade\",\"color\":\"dark_red\",\"underlined\":true}"}}}},scores={counter=..0,useCarrotStick=1..,subcounter=5..},gamemode=!spectator] run function project-c:jobaction/031/skill/0/0
-execute if entity @s[nbt={SelectedItem:{tag:{display:{Name:"{\"text\":\"Blood Blade\",\"color\":\"dark_red\",\"underlined\":true}"}}}},scores={counter=..0,damageDealt=1..},gamemode=!spectator] run scoreboard players operation @s damageDealt /= #031-15 counter
+execute if entity @s[nbt={SelectedItem:{tag:{display:{Name:"{\"text\":\"Blood Blade\",\"color\":\"dark_red\",\"underlined\":true}"}}}},scores={counter=..0,damageDealt=1..},gamemode=!spectator] run scoreboard players operation @s damageDealt /= #10 counter
 execute if entity @s[nbt={SelectedItem:{tag:{display:{Name:"{\"text\":\"Blood Blade\",\"color\":\"dark_red\",\"underlined\":true}"}}}},scores={counter=..0,damageDealt=1..},gamemode=!spectator] run scoreboard players operation @s subcounter += @s damageDealt
 execute if entity @s[nbt={SelectedItem:{tag:{display:{Name:"{\"text\":\"Blood Blade\",\"color\":\"dark_red\",\"underlined\":true}"}}}},scores={counter=..0,damageDealt=1..},gamemode=!spectator] run scoreboard players reset @s damageDealt
 execute if entity @s[scores={subcounter=101..}] run scoreboard players set @s subcounter 100

--- a/data/project-c/functions/jobaction/031/skill/0/1.mcfunction
+++ b/data/project-c/functions/jobaction/031/skill/0/1.mcfunction
@@ -9,7 +9,8 @@ execute if entity @s[team=BlueDummy] if entity @e[tag=Battle,team=!Blue,distance
 execute if entity @s[team=RedDummy] if entity @e[tag=Battle,team=!Red,distance=..3.0] as @e[tag=Battle,team=!Red,distance=..3.0] at @s anchored eyes positioned ^ ^ ^ if entity @e[tag=031-shot,team=RedDummy,distance=..1.2] run tag @s add 031-0hasHit
 execute if entity @s[team=BlueDummy] if entity @e[tag=Battle,team=!Blue,distance=..3.0] as @e[tag=Battle,team=!Blue,distance=..3.0] at @s anchored eyes positioned ^ ^ ^ if entity @e[tag=031-shot,team=BlueDummy,distance=..1.2] run tag @s add 031-0hasHit
 execute if entity @e[tag=031-0hasHit,limit=1] at @a[scores={jobNumber=31}] if score @a[scores={jobNumber=31},distance=..0.01,limit=1,sort=nearest] playerNumber = @s playerNumber as @a[tag=031-0hasHit] run scoreboard players operation @a[scores={jobNumber=31},distance=..0.01,limit=1,sort=nearest] counter_3 = @s playerNumber
-execute if entity @e[tag=031-0hasHit,limit=1] run tag @a[tag=031-0hasHit] add 031-0tDeath
+execute if entity @e[tag=031-0hasHit,limit=1] run summon area_effect_cloud ~ ~ ~ {Tags:["031blood_blade_check"],Duration:4,Age:2}
+execute if entity @e[tag=031-0hasHit,limit=1] run scoreboard players operation @e[tag=031blood_blade_check,limit=1,sort=nearest] playerNumber = @a[tag=031-0hasHit,limit=1] playerNumber
 execute if entity @e[tag=031-0hasHit,limit=1] run effect give @e[tag=031-0hasHit] instant_damage 1 0
 execute if entity @e[tag=031-0hasHit,limit=1] run scoreboard players set @s counter 100
 execute if entity @e[tag=031-0hasHit,limit=1] run particle dust 0.8 0 0 4 ^ ^ ^2 2.2 2.2 2.2 1 100 normal @a

--- a/data/project-c/functions/jobaction/031/skill/0/2.mcfunction
+++ b/data/project-c/functions/jobaction/031/skill/0/2.mcfunction
@@ -1,10 +1,10 @@
 execute at @a[scores={jobNumber=31}] if score @s playerNumber = @a[scores={jobNumber=31},distance=..0.01,limit=1,sort=nearest] counter_3 run tag @a[scores={jobNumber=31},distance=..0.01,limit=1,sort=nearest] add 031-0getkill
-execute as @a[tag=031-0getkill] at @s run particle dust 1 0 0 2.5 ~ ~ ~ 2 2 2 1 200 normal @a
-execute as @a[tag=031-0getkill] at @s run particle dust 1 0 0 2.5 ~ ~ ~ 2 2 2 1 50 force @a
-execute as @a[tag=031-0getkill] at @s run particle minecraft:witch ~ ~ ~ 2 2 2 1 300 normal @a
-execute as @a[tag=031-0getkill] at @s run particle minecraft:totem_of_undying ~ ~ ~ 0 0 0 2 300 normal @a
-execute as @a[tag=031-0getkill] at @s run particle minecraft:totem_of_undying ~ ~ ~ 0 0 0 2 75 force @a
-execute as @a[tag=031-0getkill] at @s run playsound minecraft:entity.elder_guardian.ambient master @a ~ ~ ~ 2 2
-execute as @a[tag=031-0getkill] at @s run playsound minecraft:entity.zombie_horse.death master @a ~ ~ ~ 2 0.5
+execute at @a[tag=031-0getkill] run particle dust 1 0 0 2.5 ~ ~ ~ 2 2 2 1 200 normal @a
+execute at @a[tag=031-0getkill] run particle dust 1 0 0 2.5 ~ ~ ~ 2 2 2 1 50 force @a
+execute at @a[tag=031-0getkill] run particle minecraft:witch ~ ~ ~ 2 2 2 1 300 normal @a
+execute at @a[tag=031-0getkill] run particle minecraft:totem_of_undying ~ ~ ~ 0 0 0 2 300 normal @a
+execute at @a[tag=031-0getkill] run particle minecraft:totem_of_undying ~ ~ ~ 0 0 0 2 75 force @a
+execute at @a[tag=031-0getkill] run playsound minecraft:entity.elder_guardian.ambient master @a ~ ~ ~ 2 2
+execute at @a[tag=031-0getkill] run playsound minecraft:entity.zombie_horse.death master @a ~ ~ ~ 2 0.5
 scoreboard players add @a[tag=031-0getkill] subcounter 50
 tag @a[tag=031-0getkill] remove 031-0getkill

--- a/data/project-c/functions/jobaction/031/skill/0/check.mcfunction
+++ b/data/project-c/functions/jobaction/031/skill/0/check.mcfunction
@@ -1,0 +1,4 @@
+tag @s add it
+execute if entity @a[nbt={Health:0.0f},limit=1] as @a[nbt={Health:0.0f}] if score @s playerNumber = @e[tag=it,limit=1] playerNumber run function project-c:jobaction/031/skill/0/2
+tag @s remove it
+kill @s


### PR DESCRIPTION
Wizard
・火の魔法陣の弾速を1.5→最大2.8に増加。

木こり
・第一にCT加速1秒を追加し、半径を5m→8m、回復周期を3秒→1.75秒、回復量を3→2、回復回数を6→9に調整。

Vampire
・吸血ゲージ吸収量を1.5倍に増加。