### PR TITLE
nea job 修正2

### DIFF
--- a/data/project-c/functions/jobaction/099/skill/2/own.mcfunction
+++ b/data/project-c/functions/jobaction/099/skill/2/own.mcfunction
@@ -1,6 +1,9 @@
 scoreboard players operation #099_pn_checker playerNumber = @e[tag=099-S2-AEC-this,limit=1] playerNumber
 execute if entity @s[distance=..10] if score @s playerNumber = #099_pn_checker playerNumber run tag @s add 099-S2-in-area-check-owner
+
 execute if entity @s[tag=099-S2-in-area-check-owner,scores={jobNumber=99}] run tag @s add 099-S2-in-area-own
 execute if entity @s[tag=099-S2-in-area-own,scores={deathCount=1..}] run tag @s remove 099-S2-in-area-own
+
+execute if entity @s[tag=099-S2-in-area-check-owner,scores={deathCount=1..}] run tag @s remove 099-S2-in-area-check-owner
 execute unless entity @s[tag=099-S2-in-area-check-owner] if score @s playerNumber = #099_pn_checker playerNumber run function project-c:jobaction/099/skill/2/end-1
 execute if entity @s[tag=099-S2-in-area-check-owner] run tag @s remove 099-S2-in-area-check-owner

--- a/data/project-c/functions/jobaction/106/items/skill/07/use.mcfunction
+++ b/data/project-c/functions/jobaction/106/items/skill/07/use.mcfunction
@@ -25,6 +25,7 @@ execute if entity @s[team=Blue] as @a[tag=Battle,team=Blue,distance=..4] run tag
 
 
 execute store result score #106_playerCount counter if entity @a[tag=guard_fort_target]
+execute unless score #106_playerCount counter matches 1.. run scoreboard players set #106_playerCount counter 1
 execute if entity @s[tag=skill1_use] run scoreboard players operation #106_CT counter *= #106_playerCount counter
 execute if entity @s[tag=skill2_use] run scoreboard players operation #106_CT counter *= #106_playerCount counter
 execute if entity @s[tag=skill3_use] run scoreboard players operation #106_CT counter *= #106_playerCount counter

--- a/data/project-c/functions/jobaction/118/main.mcfunction
+++ b/data/project-c/functions/jobaction/118/main.mcfunction
@@ -33,6 +33,7 @@ execute if entity @s[scores={relic=23}] run tag @s add job118-usage-prohibited
 
 execute if entity @s[tag=job118-usage-prohibited] run tellraw @s {"text":"このレリックは使えない！","bold":true,"color":"red"}
 execute if entity @s[tag=job118-usage-prohibited] at @s run playsound block.note_block.pling master @s ~ ~ ~ 1 0
+execute if entity @s[tag=job118-usage-prohibited] run replaceitem entity @s container.8 air
 execute if entity @s[tag=job118-usage-prohibited] run scoreboard players set @s relic 0
 execute if entity @s[tag=job118-usage-prohibited] run tag @s remove job118-usage-prohibited
 


### PR DESCRIPTION
99 EVOLTの領域内外検知処理の変更に伴う死亡時消滅しない問題の修正

106 ジョブマスターのガードフォートがロビー時にCTが0から増えない問題の修正(最低保証を付ける)

118 Resonanceのレリック削除処理にレリック位置のアイテムを削除する処理を追加