### PR TITLE
nea job 修正3

### DIFF
--- a/data/project-c/functions/jobaction/099/skill/1/phase4/2.mcfunction
+++ b/data/project-c/functions/jobaction/099/skill/1/phase4/2.mcfunction
@@ -24,6 +24,7 @@ execute if entity @e[type=hopper_minecart,tag=!099-S1-P4-BkillO,tag=!Stable,limi
 execute if entity @e[type=chest_minecart,tag=!099-S1-P4-BkillO,tag=!Stable,limit=1] as @e[type=chest_minecart,tag=!099-S1-P4-BkillO,tag=!Stable] run tag @s add 099-S1-P4-BkillO
 execute if entity @e[type=furnace_minecart,tag=!099-S1-P4-BkillO,tag=!Stable,limit=1] as @e[type=furnace_minecart,tag=!099-S1-P4-BkillO,tag=!Stable] run tag @s add 099-S1-P4-BkillO
 execute if entity @e[type=command_block_minecart,tag=!099-S1-P4-BkillO,tag=!Stable,limit=1] as @e[type=command_block_minecart,tag=!099-S1-P4-BkillO,tag=!Stable] run tag @s add 099-S1-P4-BkillO
+execute if entity @e[type=firework_rocket,tag=!099-S1-P4-BkillO,tag=!Stable,limit=1] as @e[type=firework_rocket,tag=!099-S1-P4-BkillO,tag=!Stable] run tag @s add 099-S1-P4-BkillO
 
 execute if entity @e[type=experience_orb,tag=!099-S1-P4-BkillO,tag=!Stable,limit=1] as @e[type=experience_orb,tag=!099-S1-P4-BkillO,tag=!Stable] run tag @s add 099-S1-P4-BkillO
 execute if entity @e[type=shulker_bullet,tag=!099-S1-P4-BkillO,tag=!Stable,limit=1] as @e[type=shulker_bullet,tag=!099-S1-P4-BkillO,tag=!Stable] run tag @s add 099-S1-P4-BkillO

--- a/data/project-c/functions/jobaction/106/items/skill/bulk.mcfunction
+++ b/data/project-c/functions/jobaction/106/items/skill/bulk.mcfunction
@@ -19,6 +19,10 @@ execute if entity @s[tag=skill1_use] run tag @s remove SkillReady1
 execute if entity @s[tag=skill2_use] run tag @s remove SkillReady2
 execute if entity @s[tag=skill3_use] run tag @s remove SkillReady3
 
+execute if entity @s[tag=skill1_use] run scoreboard players set @s usedSkill 1
+execute if entity @s[tag=skill2_use] run scoreboard players set @s usedSkill 2
+execute if entity @s[tag=skill3_use] run scoreboard players set @s usedSkill 3
+
 execute if entity @s[tag=106-support2-use--] run scoreboard players add @s CT1 20
 execute if entity @s[tag=106-support2-use--] run scoreboard players add @s CT2 20
 execute if entity @s[tag=106-support2-use--] run scoreboard players add @s CT3 20

--- a/data/project-c/functions/jobaction/118/skill/2/3.mcfunction
+++ b/data/project-c/functions/jobaction/118/skill/2/3.mcfunction
@@ -80,7 +80,7 @@ execute if entity @a[tag=118-ct-change,limit=1] as @a[tag=118-ct-change] run fun
 execute if entity @a[tag=118-ct-change,limit=1] as @a[tag=118-ct-change] run tag @s remove 118-ct-change
 
 
-execute as @a[tag=118-1--] at @s run particle minecraft:firework ~ ~1 ~ 0 0 0 0.2 20 force @a
+execute as @a[tag=118-2--] at @s run particle minecraft:firework ~ ~1 ~ 0 0 0 0.2 20 force @a
 execute at @s run particle minecraft:firework ~ ~1 ~ 0 0 0 0.2 20 force @a
 
 


### PR DESCRIPTION
Resonance CT共有で、発動主にパーティクルが出ない問題を修正

ジョブマスター スキルの発動時にusedSkillにスコアが代入されていない(オーバードーズ等が正常に動作しない)問題の修正