### PR TITLE
Resonance、Granter修正2

### DIFF
--- a/data/project-c/advancements/hiddenjob/118.json
+++ b/data/project-c/advancements/hiddenjob/118.json
@@ -4,7 +4,7 @@
       "item": "minecraft:cake"
     },
     "title": "No.-118 Granter",
-    "description": "Resonanceで一度に5種類以上のデバフを与える。",
+    "description": "Resonanceで1試合中に味方のCTと体力をそれぞれ2回回復させる。",
     "frame": "challenge",
     "show_toast": true,
     "announce_to_chat": true,
@@ -12,11 +12,18 @@
   },
   "parent": "project-c:hiddenjob/root",
   "criteria": {
-    "requirement": {
-      "trigger": "minecraft:impossible"
-    }
-    },
-      "rewards": {
+    "ad1.1": {"trigger": "minecraft:impossible"},
+    "ad1.2": {"trigger": "minecraft:impossible"},
+    "ad2.1": {"trigger": "minecraft:impossible"},
+    "ad2.2": {"trigger": "minecraft:impossible"}
+  },
+  "requirements": [
+    ["ad1.1"],
+    ["ad1.2"],
+    ["ad2.1"],
+    ["ad2.2"]
+  ],
+  "rewards": {
     "function": "project-c:hiddenjob/-118/jobunlocked"
   }
 }

--- a/data/project-c/functions/hiddenjob/-118/main.mcfunction
+++ b/data/project-c/functions/hiddenjob/-118/main.mcfunction
@@ -1,4 +1,4 @@
-#実行者     -> jobNumber = 118
+#実行者     -> jobNumber = -118
 #実行地点   -> 実行者
 #counter    -> 選択プレイヤー保持用
 
@@ -15,18 +15,18 @@ execute if entity @s[scores={useCarrotStick=1..},gamemode=!spectator] run functi
 execute if entity @s[scores={counter=1..},gamemode=!spectator] run function project-c:hiddenjob/-118/skill/0/1
 
 
-execute if entity @s[scores={relic=4}] run tag @s add job118-usage-prohibited
-execute if entity @s[scores={relic=5}] run tag @s add job118-usage-prohibited
-execute if entity @s[scores={relic=14}] run tag @s add job118-usage-prohibited
-execute if entity @s[scores={relic=21}] run tag @s add job118-usage-prohibited
-execute if entity @s[scores={relic=23}] run tag @s add job118-usage-prohibited
+#execute if entity @s[scores={relic=4}] run tag @s add job-118-usage-prohibited
+#execute if entity @s[scores={relic=5}] run tag @s add job-118-usage-prohibited
+#execute if entity @s[scores={relic=14}] run tag @s add job-118-usage-prohibited
+#execute if entity @s[scores={relic=21}] run tag @s add job-118-usage-prohibited
+#execute if entity @s[scores={relic=23}] run tag @s add job-118-usage-prohibited
+execute if entity @s[scores={relic=27}] run tag @s add job-118-usage-prohibited
 
-execute if entity @s[tag=job118-usage-prohibited] run tellraw @s {"text":"このレリックは使えない！","bold":true,"color":"red"}
-execute if entity @s[tag=job118-usage-prohibited] at @s run playsound block.note_block.pling master @s ~ ~ ~ 1 0
-execute if entity @s[tag=job118-usage-prohibited] run replaceitem entity @s container.8 air
-execute if entity @s[tag=job118-usage-prohibited] run scoreboard players set @s relic 0
-execute if entity @s[tag=job118-usage-prohibited] run tag @s remove job118-usage-prohibited
+execute if entity @s[tag=job-118-usage-prohibited] run tellraw @s {"text":"このレリックは使えない！","bold":true,"color":"red"}
+execute if entity @s[tag=job-118-usage-prohibited] at @s run playsound block.note_block.pling master @s ~ ~ ~ 1 0
+execute if entity @s[tag=job-118-usage-prohibited] run replaceitem entity @s container.8 air
+execute if entity @s[tag=job-118-usage-prohibited] run scoreboard players set @s relic 0
+execute if entity @s[tag=job-118-usage-prohibited] run tag @s remove job-118-usage-prohibited
 
 
-#tag @s[tag=!job-118] add job-118
 scoreboard players reset @s[scores={useCarrotStick=1..}] useCarrotStick

--- a/data/project-c/functions/hiddenjob/-118/skill/1/0.mcfunction
+++ b/data/project-c/functions/hiddenjob/-118/skill/1/0.mcfunction
@@ -19,10 +19,12 @@ execute as @a[tag=-118-1-a] store result score #-118 counter_2 run data get enti
 scoreboard players operation #-118 counter_1 /= #2 counter
 
 scoreboard players operation @s ScoreToHealth = #-118 counter_1
-scoreboard players operation #-118 counter_1 += #-118 counter_2
-execute as @a[tag=-118-1-a] run scoreboard players operation @s ScoreToHealth = #-118 counter_1
+scoreboard players operation #-118 counter_2 += #-118 counter_1
+execute as @a[tag=-118-1-a] run scoreboard players operation @s ScoreToHealth = #-118 counter_2
 
 
+scoreboard players operation #-118 counter_1 /= #100 counter
+execute if entity @a[tag=-118-1-a,limit=1] as @a[tag=-118-1-a] run tellraw @s ["",{"score":{"name":"#-118","objective": "counter_1"},"color":"green"},{"text":"回復","color":"green"},{"text":" <- "},{"selector":"@a[tag=-118-,limit=1]"}]
 execute if entity @a[tag=-118-1-a,limit=1] at @a[tag=-118-1-a] run playsound entity.player.levelup master @a ~ ~ ~ 1 0
 execute if entity @a[tag=-118-1-a,limit=1] at @a[tag=-118-1-a] run playsound entity.player.levelup master @a ~ ~ ~ 1 0
 execute if entity @a[tag=-118-1-a,limit=1] at @a[tag=-118-1-a] run particle minecraft:totem_of_undying ~ ~1 ~ 0 0 0 0.5 20 force @a

--- a/data/project-c/functions/hiddenjob/-118/skill/1/0.mcfunction
+++ b/data/project-c/functions/hiddenjob/-118/skill/1/0.mcfunction
@@ -9,6 +9,8 @@ particle minecraft:totem_of_undying ~ ~1 ~ 0 0 0 0.5 20 force @a
 
 tag @s add -118-
 
+scoreboard players set @s OutCombat 0
+
 execute as @a[tag=Battle] if score @s playerNumber = @a[tag=-118-,limit=1] counter run tag @s add -118-1-a
 execute if entity @a[tag=-118-1-a,limit=1] at @a[tag=-118-1-a] facing entity @a[tag=-118-,limit=1] feet run function project-c:hiddenjob/-118/skill/1/particle
 

--- a/data/project-c/functions/hiddenjob/-118/skill/2/0.mcfunction
+++ b/data/project-c/functions/hiddenjob/-118/skill/2/0.mcfunction
@@ -10,7 +10,7 @@ particle minecraft:firework ~ ~1 ~ 0 0 0 0.2 20 force @a
 tag @s add -118-
 
 execute as @a[tag=Battle] if score @s playerNumber = @a[tag=-118-,limit=1] counter run tag @s add -118-2-a
-execute if entity @a[tag=-118-2-a,limit=1] at @a[tag=-118-2-a] facing entity @a[tag=-118-,limit=1] feet run function project-c:jobaction/118/skill/2/particle
+execute if entity @a[tag=-118-2-a,limit=1] at @a[tag=-118-2-a] facing entity @a[tag=-118-,limit=1] feet run function project-c:hiddenjob/-118/skill/2/particle
 
 
 
@@ -84,6 +84,7 @@ execute if entity @s[tag=-118-ct-change] run function project-c:general/cooltime
 execute if entity @s[tag=-118-ct-change] run tag @s remove 118-ct-change
 
 
+execute if entity @a[tag=-118-2-a,limit=1] as @a[tag=-118-2-a] run tellraw @s ["",{"text":"CT吸収","color":"light_purple"},{"text":" <- "},{"selector":"@a[tag=-118-,limit=1]"}]
 execute if entity @a[tag=-118-2-a,limit=1] at @a[tag=-118-2-a] run playsound minecraft:entity.illusioner.cast_spell master @a ~ ~ ~ 1.3 2
 execute if entity @a[tag=-118-2-a,limit=1] at @a[tag=-118-2-a] run particle minecraft:firework ~ ~1 ~ 0 0 0 0.2 20 force @a
 

--- a/data/project-c/functions/hiddenjob/-118/skill/2/particle.mcfunction
+++ b/data/project-c/functions/hiddenjob/-118/skill/2/particle.mcfunction
@@ -1,3 +1,3 @@
 
-execute unless entity @s[distance=..1] positioned ~ ~1.15 ~ run particle minecraft:angry_villager ^ ^ ^1 0 0 0 0 1 force @a
-execute unless entity @s[distance=..1] positioned ^ ^ ^1 run function project-c:jobaction/118/skill/2/particle
+execute unless entity @s[distance=..1] positioned ~ ~1.15 ~ run particle minecraft:happy_villager ^ ^ ^1 0 0 0 0 1 force @a
+execute unless entity @s[distance=..1] positioned ^ ^ ^1 run function project-c:hiddenjob/-118/skill/2/particle

--- a/data/project-c/functions/jobaction/118/main.mcfunction
+++ b/data/project-c/functions/jobaction/118/main.mcfunction
@@ -28,6 +28,8 @@ execute if entity @s[scores={counter_1=1..},gamemode=!spectator] run function pr
 execute if entity @s[scores={counter_2=1..},gamemode=!spectator] run function project-c:jobaction/118/skill/2/1
 
 
+execute if entity @s[tag=job118-advancement2.trigger] run tag @s remove job118-advancement2.trigger
+
 
 execute if entity @s[scores={relic=4}] run tag @s add job118-usage-prohibited
 execute if entity @s[scores={relic=5}] run tag @s add job118-usage-prohibited

--- a/data/project-c/functions/jobaction/118/main.mcfunction
+++ b/data/project-c/functions/jobaction/118/main.mcfunction
@@ -1,12 +1,16 @@
 #実行者     -> jobNumber = 118
 #実行地点   -> 実行者
 #counter    -> 選択プレイヤー保持用
-#subcounter -> スキル1のスパン
 #counter_1    -> スキル1の使用時間
 #counter_2    -> スキル2の使用時間
 #counter_3    -> スキル1の選択プレイヤー保持
+#subcounter   -> スキル1のスパン
 #counter_4    -> スキル2の選択プレイヤー保持
 #counter_9    -> スキル2のスパン
+
+
+#counter_5    -> スキル1のチェック用
+#counter_6    -> スキル2のチェック用
 
 scoreboard players reset @s usedSkill
 
@@ -38,5 +42,12 @@ execute if entity @s[tag=job118-usage-prohibited] run scoreboard players set @s 
 execute if entity @s[tag=job118-usage-prohibited] run tag @s remove job118-usage-prohibited
 
 
-#tag @s[tag=!job118] add job118
+
+#進捗用処理
+execute if entity @s[scores={advancement1=1},advancements={project-c:hiddenjob/118={ad1.1=false}}] run advancement grant @s only project-c:hiddenjob/118 ad1.1
+execute if entity @s[scores={advancement1=2..},advancements={project-c:hiddenjob/118={ad1.2=false}}] run advancement grant @s only project-c:hiddenjob/118 ad1.2
+execute if entity @s[scores={advancement2=1},advancements={project-c:hiddenjob/118={ad2.1=false}}] run advancement grant @s only project-c:hiddenjob/118 ad2.1
+execute if entity @s[scores={advancement2=2..},advancements={project-c:hiddenjob/118={ad2.2=false}}] run advancement grant @s only project-c:hiddenjob/118 ad2.2
+
+
 scoreboard players reset @s[scores={useCarrotStick=1..}] useCarrotStick

--- a/data/project-c/functions/jobaction/118/skill/0/reset-me---.mcfunction
+++ b/data/project-c/functions/jobaction/118/skill/0/reset-me---.mcfunction
@@ -5,3 +5,5 @@ scoreboard players reset @s counter_1
 scoreboard players reset @s counter_2
 scoreboard players reset @s counter_3
 scoreboard players reset @s counter_4
+scoreboard players reset @s counter_5
+scoreboard players reset @s counter_6

--- a/data/project-c/functions/jobaction/118/skill/1/0.mcfunction
+++ b/data/project-c/functions/jobaction/118/skill/1/0.mcfunction
@@ -30,6 +30,7 @@ tag @s remove 118-
 title @s actionbar [{"text":""}]
 scoreboard players reset @s counter
 scoreboard players reset @s subcounter
+scoreboard players reset @s counter_5
 
 tag @s remove SkillReady1
 scoreboard players set @s usedSkill 1

--- a/data/project-c/functions/jobaction/118/skill/1/1.mcfunction
+++ b/data/project-c/functions/jobaction/118/skill/1/1.mcfunction
@@ -1,4 +1,5 @@
 scoreboard players remove @s counter_1 1
+scoreboard players add @s counter_5 1
 scoreboard players add @s subcounter 1
 
 scoreboard players set @s OutCombat 0

--- a/data/project-c/functions/jobaction/118/skill/1/3.mcfunction
+++ b/data/project-c/functions/jobaction/118/skill/1/3.mcfunction
@@ -2,6 +2,8 @@
 execute store result score #118-- counter_1 run data get entity @s Health 100
 execute as @a[tag=118-1--] store result score #118-- counter_2 run data get entity @s Health 100
 
+execute as @a[tag=118-1--] if score @s counter_5 matches 1 if score #118-- counter_1 < #118-- counter_2 run scoreboard players add @s advancement1 1
+
 scoreboard players operation #118-- counter_1 += #118-- counter_2
 scoreboard players operation #118-- counter_1 /= #2 counter
 

--- a/data/project-c/functions/jobaction/118/skill/1/3.mcfunction
+++ b/data/project-c/functions/jobaction/118/skill/1/3.mcfunction
@@ -2,7 +2,8 @@
 execute store result score #118-- counter_1 run data get entity @s Health 100
 execute as @a[tag=118-1--] store result score #118-- counter_2 run data get entity @s Health 100
 
-execute as @a[tag=118-1--] if score @s counter_5 matches 1 if score #118-- counter_1 < #118-- counter_2 run scoreboard players add @s advancement1 1
+scoreboard players operation #118-- teamNumber = @a[tag=118-1--,limit=1] teamNumber
+execute if score @s teamNumber = #118-- teamNumber as @a[tag=118-1--] if score @s counter_5 matches 1 if score #118-- counter_1 < #118-- counter_2 run scoreboard players add @s advancement1 1
 
 scoreboard players operation #118-- counter_1 += #118-- counter_2
 scoreboard players operation #118-- counter_1 /= #2 counter

--- a/data/project-c/functions/jobaction/118/skill/2/0.mcfunction
+++ b/data/project-c/functions/jobaction/118/skill/2/0.mcfunction
@@ -6,6 +6,8 @@ scoreboard players operation @s counter_2 = #118-- counter
 playsound minecraft:entity.villager.death master @a ~ ~ ~ 1 0
 particle minecraft:firework ~ ~1 ~ 0 0 0 0.2 20 force @a
 
+execute if entity @s[scores={CT1=1200..,CT3=1200..}] run tag @s add job118-advancement2.trigger
+
 tag @s add 118-
 scoreboard players operation @s counter_4 = @s counter
 
@@ -26,3 +28,4 @@ function project-c:jobaction/118/replaceitem/2
 title @s actionbar [{"text":""}]
 scoreboard players reset @s counter
 scoreboard players reset @s counter_9
+scoreboard players reset @s counter_6

--- a/data/project-c/functions/jobaction/118/skill/2/1.mcfunction
+++ b/data/project-c/functions/jobaction/118/skill/2/1.mcfunction
@@ -1,4 +1,5 @@
 scoreboard players remove @s counter_2 1
+scoreboard players add @s counter_6 1
 scoreboard players add @s counter_9 1
 
 execute if score @s counter_9 matches 1 run function project-c:jobaction/118/skill/2/2

--- a/data/project-c/functions/jobaction/118/skill/2/3.mcfunction
+++ b/data/project-c/functions/jobaction/118/skill/2/3.mcfunction
@@ -4,6 +4,8 @@ scoreboard players set #118-- counter_2 1200
 scoreboard players operation #118-- counter_1 -= @s CT1
 scoreboard players operation #118-- counter_2 -= @a[tag=118-2--,limit=1] CT1
 
+execute as @a[tag=118-2--,tag=job118-advancement2.trigger] if score @s counter_6 matches 1 if score #118-- counter_1 matches 1.. run tag @s add job118-advancement2.ct1
+
 execute if score #118-- counter_1 matches ..-1 run scoreboard players set #118-- counter_1 0
 execute if score #118-- counter_2 matches ..-1 run scoreboard players set #118-- counter_2 0
 
@@ -42,6 +44,8 @@ scoreboard players set #118-- counter_2 1200
 scoreboard players operation #118-- counter_1 -= @s CT3
 scoreboard players operation #118-- counter_2 -= @a[tag=118-2--,limit=1] CT3
 
+execute as @a[tag=118-2--,tag=job118-advancement2.trigger] if score @s counter_6 matches 1 if score #118-- counter_1 matches 1.. run tag @s add job118-advancement2.ct3
+
 execute if score #118-- counter_1 matches ..-1 run scoreboard players set #118-- counter_1 0
 execute if score #118-- counter_2 matches ..-1 run scoreboard players set #118-- counter_2 0
 
@@ -52,7 +56,6 @@ scoreboard players operation #118-- counter_2 -= #118-- counter_1
 
 scoreboard players operation @s CT3 = #118-- counter_2
 execute as @a[tag=118-2--] run scoreboard players operation @s CT3 = #118-- counter_2
-
 
 
 execute if entity @s[scores={CT1=..1199}] run tag @s add 118-ct-change
@@ -83,5 +86,13 @@ execute if entity @a[tag=118-ct-change,limit=1] as @a[tag=118-ct-change] run tag
 execute as @a[tag=118-2--] at @s run particle minecraft:firework ~ ~1 ~ 0 0 0 0.2 20 force @a
 execute at @s run particle minecraft:firework ~ ~1 ~ 0 0 0 0.2 20 force @a
 
+execute as @a[tag=118-2--,tag=job118-advancement2.trigger,tag=job118-advancement2.ct1] run tag @s add job118-advancement2.ok
+execute as @a[tag=118-2--,tag=job118-advancement2.trigger,tag=job118-advancement2.ct3] run tag @s add job118-advancement2.ok
+
+execute as @a[tag=118-2--,tag=job118-advancement2.trigger,tag=job118-advancement2.ok] run scoreboard players add @s advancement2 1
+execute as @a[tag=118-2--,tag=job118-advancement2.ct1] run tag @s remove job118-advancement2.ct1
+execute as @a[tag=118-2--,tag=job118-advancement2.ct3] run tag @s remove job118-advancement2.ct3
+execute as @a[tag=118-2--,tag=job118-advancement2.trigger] run tag @s remove job118-advancement2.trigger
+execute as @a[tag=118-2--,tag=job118-advancement2.ok] run tag @s remove job118-advancement2.ok
 
 scoreboard players reset #118--

--- a/data/project-c/functions/jobaction/118/skill/2/3.mcfunction
+++ b/data/project-c/functions/jobaction/118/skill/2/3.mcfunction
@@ -4,7 +4,8 @@ scoreboard players set #118-- counter_2 1200
 scoreboard players operation #118-- counter_1 -= @s CT1
 scoreboard players operation #118-- counter_2 -= @a[tag=118-2--,limit=1] CT1
 
-execute as @a[tag=118-2--,tag=job118-advancement2.trigger] if score @s counter_6 matches 1 if score #118-- counter_1 matches 1.. run tag @s add job118-advancement2.ct1
+scoreboard players operation #118-- teamNumber = @a[tag=118-2--,limit=1] teamNumber
+execute if score @s teamNumber = #118-- teamNumber as @a[tag=118-2--,tag=job118-advancement2.trigger] if score @s counter_6 matches 1 if score #118-- counter_1 matches 1.. run tag @s add job118-advancement2.ct1
 
 execute if score #118-- counter_1 matches ..-1 run scoreboard players set #118-- counter_1 0
 execute if score #118-- counter_2 matches ..-1 run scoreboard players set #118-- counter_2 0
@@ -25,6 +26,8 @@ scoreboard players set #118-- counter_2 1200
 scoreboard players operation #118-- counter_1 -= @s CT2
 scoreboard players operation #118-- counter_2 -= @a[tag=118-2--,limit=1] CT2
 
+execute if score @s teamNumber = #118-- teamNumber as @a[tag=118-2--,tag=job118-advancement2.trigger] if score @s counter_6 matches 1 if score #118-- counter_1 matches 1.. run tag @s add job118-advancement2.ct2
+
 execute if score #118-- counter_1 matches ..-1 run scoreboard players set #118-- counter_1 0
 execute if score #118-- counter_2 matches ..-1 run scoreboard players set #118-- counter_2 0
 
@@ -44,7 +47,7 @@ scoreboard players set #118-- counter_2 1200
 scoreboard players operation #118-- counter_1 -= @s CT3
 scoreboard players operation #118-- counter_2 -= @a[tag=118-2--,limit=1] CT3
 
-execute as @a[tag=118-2--,tag=job118-advancement2.trigger] if score @s counter_6 matches 1 if score #118-- counter_1 matches 1.. run tag @s add job118-advancement2.ct3
+execute if score @s teamNumber = #118-- teamNumber as @a[tag=118-2--,tag=job118-advancement2.trigger] if score @s counter_6 matches 1 if score #118-- counter_1 matches 1.. run tag @s add job118-advancement2.ct3
 
 execute if score #118-- counter_1 matches ..-1 run scoreboard players set #118-- counter_1 0
 execute if score #118-- counter_2 matches ..-1 run scoreboard players set #118-- counter_2 0
@@ -86,13 +89,14 @@ execute if entity @a[tag=118-ct-change,limit=1] as @a[tag=118-ct-change] run tag
 execute as @a[tag=118-2--] at @s run particle minecraft:firework ~ ~1 ~ 0 0 0 0.2 20 force @a
 execute at @s run particle minecraft:firework ~ ~1 ~ 0 0 0 0.2 20 force @a
 
-execute as @a[tag=118-2--,tag=job118-advancement2.trigger,tag=job118-advancement2.ct1] run tag @s add job118-advancement2.ok
-execute as @a[tag=118-2--,tag=job118-advancement2.trigger,tag=job118-advancement2.ct3] run tag @s add job118-advancement2.ok
+execute as @a[tag=118-2--,tag=job118-advancement2.ct1] run tag @s add job118-advancement2.ok
+execute as @a[tag=118-2--,tag=job118-advancement2.ct2] run tag @s add job118-advancement2.ok
+execute as @a[tag=118-2--,tag=job118-advancement2.ct3] run tag @s add job118-advancement2.ok
 
-execute as @a[tag=118-2--,tag=job118-advancement2.trigger,tag=job118-advancement2.ok] run scoreboard players add @s advancement2 1
+execute as @a[tag=118-2--,tag=job118-advancement2.ok] run scoreboard players add @s advancement2 1
 execute as @a[tag=118-2--,tag=job118-advancement2.ct1] run tag @s remove job118-advancement2.ct1
+execute as @a[tag=118-2--,tag=job118-advancement2.ct2] run tag @s remove job118-advancement2.ct2
 execute as @a[tag=118-2--,tag=job118-advancement2.ct3] run tag @s remove job118-advancement2.ct3
-execute as @a[tag=118-2--,tag=job118-advancement2.trigger] run tag @s remove job118-advancement2.trigger
 execute as @a[tag=118-2--,tag=job118-advancement2.ok] run tag @s remove job118-advancement2.ok
 
 scoreboard players reset #118--

--- a/data/project-c/functions/jobaction/118/skill/3/0.mcfunction
+++ b/data/project-c/functions/jobaction/118/skill/3/0.mcfunction
@@ -41,8 +41,6 @@ execute as @e[tag=118-evil,nbt={Effects:[{Id:28b}]}] run data remove entity @s E
 execute as @e[tag=118-evil,nbt={Effects:[{Id:29b}]}] run data remove entity @s Effects[{Id:29b}]
 execute as @e[tag=118-evil,nbt={Effects:[{Id:30b}]}] run data remove entity @s Effects[{Id:30b}]
 execute as @e[tag=118-evil,nbt={Effects:[{Id:32b}]}] run data remove entity @s Effects[{Id:32b}]
-execute store result score @s advancement1 as @e[tag=118-evil,limit=1] run data get entity @s Effects
-execute if entity @s[advancements={project-c:hiddenjob/118=false},scores={advancement1=5..}] run advancement grant @s only project-c:hiddenjob/118
 execute as @e[tag=118-evil] run tag @s remove 118-evil
 
 execute as @a[tag=118-3---h] run tag @s remove 118-3---h


### PR DESCRIPTION
Resonance、Granterの修正2
---
* Granterの開放条件の変更
Resonanceで1試合中に味方のCTと体力をそれぞれ2回回復させる。
* GranterにResonanceと同じようなチャットを行うように変更
Health Grant は 「OO回復 <- PlayerID」
Cooltime Grant は「CT吸収 <- PlayerID」と表示される。
* Granterの使用可能レリックの変更
「ワイルドカード」を使用不可に、それ以外を使用可能に。
* Granterの初期化処理の追加
* Granterの第1スキルでOutCombatがリセットされない問題の修正
* その他記述ミス等の修正