### PR TITLE
job129 デストーテムのバフ＆バグ修正

### DIFF
--- a/data/project-c/functions/general/talk-villager/villager-check.mcfunction
+++ b/data/project-c/functions/general/talk-villager/villager-check.mcfunction
@@ -6,7 +6,7 @@ tag @s add talkV-anchor
 #テスト用村人のやつなので消したかったら消してくれ(?)
 execute if entity @e[tag=hit,tag=cclemon,limit=1] as @e[tag=hit,tag=cclemon] run say C C LEMON 夢ならば
 
-execute if entity @e[tag=hit,tag=129-totem,limit=1] run function project-c:jobaction/129/skill/2/totem/use-check
+execute if entity @e[tag=hit,tag=129-totemV,limit=1] run function project-c:jobaction/129/skill/2/totem/use-check
 
 
 

--- a/data/project-c/functions/jobaction/129/skill/1/1.mcfunction
+++ b/data/project-c/functions/jobaction/129/skill/1/1.mcfunction
@@ -6,5 +6,7 @@ execute if data entity @s {OnGround:0b} run tag @s add 129-silenth-deploy-stand-
 execute if data entity @s[tag=129-silenth-deploy-stand-by] {OnGround:1b} run tag @s add 129-silenth-deploy
 execute if data entity @s[tag=129-silenth-deploy-stand-by] {OnGround:1b} run tag @s remove 129-silenth-deploy-stand-by
 
+data merge entity @s {Fire:0}
+
 execute if entity @s[tag=129-silenth-deploy,tag=!129-silenth-deploying] run function project-c:jobaction/129/skill/1/deploy
 execute if entity @s[tag=129-silenth-deploying] run function project-c:jobaction/129/skill/1/deploying

--- a/data/project-c/functions/jobaction/129/skill/1/deploy.mcfunction
+++ b/data/project-c/functions/jobaction/129/skill/1/deploy.mcfunction
@@ -3,8 +3,7 @@ particle minecraft:dust 1 0 0 1 ~ ~ ~ 1 1 1 0 20 force
 particle minecraft:dust 0 0 0 1 ~ ~ ~ 1 1 1 0 20 force
 playsound minecraft:entity.generic.explode master @a ~ ~ ~ 1 1.8
 
-#summon armor_stand ~ ~-0.1 ~ {Small:1b,NoBasePlate:1b,Marker:1b,Invisible:1b,Tags:["129-silenth-pos","this"]}
-summon armor_stand ~ ~-0.3 ~ {Tags:["129-silenth-pos","this"],Invisible:1b,NoBasePlate:1b,Small:1b,Marker:1b,Passengers:[{id:"minecraft:item",Tags:["isItem","this","129-silenth","129-silenth-deploying"],Owner:[I;0,0,0,0],Glowing:1b,Invulnerable:1b,Item:{id:"minecraft:stone",Count:1b}}]}
+summon armor_stand ~ ~-0.3 ~ {Tags:["129-silenth-Am","this"],Invisible:1b,NoBasePlate:1b,Small:1b,Marker:1b,Passengers:[{id:"minecraft:item",Tags:["isItem","this","129-silenth","129-silenth-deploying"],Owner:[I;0,0,0,0],Glowing:1b,Invulnerable:1b,Item:{id:"minecraft:stone",Count:1b}}]}
 data modify entity @e[type=item,tag=this,limit=1] Item set from entity @s Item
 team join DarkGray @e[type=item,tag=this]
 scoreboard players operation @e[tag=this] playerNumber = @s playerNumber

--- a/data/project-c/functions/jobaction/129/skill/1/deploying.mcfunction
+++ b/data/project-c/functions/jobaction/129/skill/1/deploying.mcfunction
@@ -10,7 +10,7 @@ scoreboard players operation #129- stockcounter = @s stockcounter
 execute as @a[distance=..3,tag=Battle] unless score @s teamNumber = #129- teamNumber run tag @s add hit
 execute if entity @a[tag=hit,limit=1] as @a[tag=hit] run function project-c:jobaction/129/skill/1/already-check
 
-execute as @e[tag=129-silenth-pos] if score @s stockcounter = #129- stockcounter run tag @s add kp
+execute as @e[tag=129-silenth-Am] if score @s stockcounter = #129- stockcounter run tag @s add kp
 execute at @e[tag=kp] run tp @s ~ ~ ~
 execute as @e[tag=kp] run tag @s remove kp
 

--- a/data/project-c/functions/jobaction/129/skill/1/end.mcfunction
+++ b/data/project-c/functions/jobaction/129/skill/1/end.mcfunction
@@ -4,7 +4,7 @@ playsound minecraft:block.piston.extend master @a ~ ~ ~ 1 0.7
 scoreboard players operation #129- stockcounter = @s stockcounter
 scoreboard players operation #129- playerNumber = @s playerNumber
 execute if entity @e[tag=129-silenth-anchor,limit=1] as @e[tag=129-silenth-anchor] if score @s stockcounter = #129- stockcounter run tag @s add kill
-execute if entity @e[tag=129-silenth-pos,limit=1] as @e[tag=129-silenth-pos] if score @s stockcounter = #129- stockcounter run tag @s add kill
+execute if entity @e[tag=129-silenth-Am,limit=1] as @e[tag=129-silenth-Am] if score @s stockcounter = #129- stockcounter run tag @s add kill
 tag @s add kill
 
 execute as @e[tag=kill] run kill @s

--- a/data/project-c/functions/jobaction/129/skill/2/1.mcfunction
+++ b/data/project-c/functions/jobaction/129/skill/2/1.mcfunction
@@ -3,11 +3,11 @@ scoreboard players remove @s counter 1
 
 particle dust 0.2 0 0 1 ~ ~1 ~ 0.2 0.4 0.2 0 3 force
 summon minecraft:area_effect_cloud ~ ~ ~ {Duration:1,Tags:["this"]}
-execute anchored feet run tp @e[tag=this,limit=1] ^ ^ ^ ~ ~
-execute as @e[tag=this,limit=1] at @s rotated ~45 -65 run function project-c:jobaction/129/skill/2/totem/particle
-execute as @e[tag=this,limit=1] at @s rotated ~135 -65 run function project-c:jobaction/129/skill/2/totem/particle
-execute as @e[tag=this,limit=1] at @s rotated ~225 -65 run function project-c:jobaction/129/skill/2/totem/particle
-execute as @e[tag=this,limit=1] at @s rotated ~315 -65 run function project-c:jobaction/129/skill/2/totem/particle
+execute anchored feet run tp @e[tag=this,limit=1] ~ ~2.05 ~ ~ ~
+execute as @e[tag=this,limit=1] at @s rotated ~45 65 run function project-c:jobaction/129/skill/2/totem/particle
+execute as @e[tag=this,limit=1] at @s rotated ~135 65 run function project-c:jobaction/129/skill/2/totem/particle
+execute as @e[tag=this,limit=1] at @s rotated ~225 65 run function project-c:jobaction/129/skill/2/totem/particle
+execute as @e[tag=this,limit=1] at @s rotated ~315 65 run function project-c:jobaction/129/skill/2/totem/particle
 
 execute at @s run tp @s ~ ~ ~ ~1 0
 
@@ -51,20 +51,54 @@ execute at @s rotated ~270 0 positioned ^-0.1 ^ ^0.35 run particle dust 0.7 0 0 
 execute at @s rotated ~270 0 positioned ^0.2 ^ ^0.35 run particle dust 0.7 0 0 0.3 ~ ~1 ~ 0 0 0 0 1 force
 execute at @s rotated ~270 0 positioned ^-0.2 ^ ^0.35 run particle dust 0.7 0 0 0.3 ~ ~1 ~ 0 0 0 0 1 force
 
+
+execute at @s align xyz positioned ~0.5 ~ ~0.5 rotated 0 0 run particle dust 0.3 0 0 0.5 ^ ^ ^0.5 0 0 0 0 1 force
+execute at @s align xyz positioned ~0.5 ~ ~0.5 rotated 18 0 run particle dust 0.3 0 0 0.5 ^ ^ ^0.5 0 0 0 0 1 force
+execute at @s align xyz positioned ~0.5 ~ ~0.5 rotated 36 0 run particle dust 0.3 0 0 0.5 ^ ^ ^0.5 0 0 0 0 1 force
+execute at @s align xyz positioned ~0.5 ~ ~0.5 rotated 54 0 run particle dust 0.3 0 0 0.5 ^ ^ ^0.5 0 0 0 0 1 force
+execute at @s align xyz positioned ~0.5 ~ ~0.5 rotated 72 0 run particle dust 0.3 0 0 0.5 ^ ^ ^0.5 0 0 0 0 1 force
+execute at @s align xyz positioned ~0.5 ~ ~0.5 rotated 90 0 run particle dust 0.3 0 0 0.5 ^ ^ ^0.5 0 0 0 0 1 force
+execute at @s align xyz positioned ~0.5 ~ ~0.5 rotated 108 0 run particle dust 0.3 0 0 0.5 ^ ^ ^0.5 0 0 0 0 1 force
+execute at @s align xyz positioned ~0.5 ~ ~0.5 rotated 126 0 run particle dust 0.3 0 0 0.5 ^ ^ ^0.5 0 0 0 0 1 force
+execute at @s align xyz positioned ~0.5 ~ ~0.5 rotated 144 0 run particle dust 0.3 0 0 0.5 ^ ^ ^0.5 0 0 0 0 1 force
+execute at @s align xyz positioned ~0.5 ~ ~0.5 rotated 162 0 run particle dust 0.3 0 0 0.5 ^ ^ ^0.5 0 0 0 0 1 force
+execute at @s align xyz positioned ~0.5 ~ ~0.5 rotated 180 0 run particle dust 0.3 0 0 0.5 ^ ^ ^0.5 0 0 0 0 1 force
+execute at @s align xyz positioned ~0.5 ~ ~0.5 rotated 198 0 run particle dust 0.3 0 0 0.5 ^ ^ ^0.5 0 0 0 0 1 force
+execute at @s align xyz positioned ~0.5 ~ ~0.5 rotated 216 0 run particle dust 0.3 0 0 0.5 ^ ^ ^0.5 0 0 0 0 1 force
+execute at @s align xyz positioned ~0.5 ~ ~0.5 rotated 234 0 run particle dust 0.3 0 0 0.5 ^ ^ ^0.5 0 0 0 0 1 force
+execute at @s align xyz positioned ~0.5 ~ ~0.5 rotated 252 0 run particle dust 0.3 0 0 0.5 ^ ^ ^0.5 0 0 0 0 1 force
+execute at @s align xyz positioned ~0.5 ~ ~0.5 rotated 270 0 run particle dust 0.3 0 0 0.5 ^ ^ ^0.5 0 0 0 0 1 force
+execute at @s align xyz positioned ~0.5 ~ ~0.5 rotated 288 0 run particle dust 0.3 0 0 0.5 ^ ^ ^0.5 0 0 0 0 1 force
+execute at @s align xyz positioned ~0.5 ~ ~0.5 rotated 306 0 run particle dust 0.3 0 0 0.5 ^ ^ ^0.5 0 0 0 0 1 force
+execute at @s align xyz positioned ~0.5 ~ ~0.5 rotated 324 0 run particle dust 0.3 0 0 0.5 ^ ^ ^0.5 0 0 0 0 1 force
+execute at @s align xyz positioned ~0.5 ~ ~0.5 rotated 342 0 run particle dust 0.3 0 0 0.5 ^ ^ ^0.5 0 0 0 0 1 force
+
+
+
 kill @e[tag=this]
 
 
-tag @s remove 129-totem-me
 scoreboard players add @s Mana 1
 execute if score @s Mana matches 1 run playsound minecraft:block.conduit.ambient master @a ~ ~ ~ 1 1.3
 execute if score @s Mana matches 61.. run scoreboard players set @s Mana 0
 
+
+execute as @e[type=villager,tag=129-totemV] if score @s stockcounter = #129- stockcounter run tag @s add 129-totemV-check
+
+execute if entity @e[tag=129-totemV-check,limit=1] as @e[tag=129-totemV-check] store result score #129- HarfHP run data get entity @s Health 10
+
+execute unless entity @e[tag=129-totemV-check,limit=1] run function project-c:jobaction/129/skill/2/totem/replace-villager
+
+execute if entity @e[tag=129-totemV-check,limit=1] as @e[tag=129-totemV-check] run tag @s remove 129-totemV-check
+
 scoreboard players operation @s Damage = @s HarfHP
-execute store result score @s HarfHP run data get entity @s Health 10
+scoreboard players operation @s HarfHP = #129- HarfHP
 execute unless score @s Damage = @s HarfHP if score @s HarfHP matches 9800.. run playsound minecraft:entity.zombie.attack_iron_door master @a ~ ~ ~ 0.6 1.2
 execute unless score @s HarfHP matches 9800.. run function project-c:jobaction/129/skill/2/totem/break
 
 execute unless score @s counter matches 1.. run function project-c:jobaction/129/skill/2/totem/end-check
 
 
-scoreboard players reset #129- stockcounter
+scoreboard players reset #129-
+
+tag @s remove 129-totem-me

--- a/data/project-c/functions/jobaction/129/skill/2/totem/break.mcfunction
+++ b/data/project-c/functions/jobaction/129/skill/2/totem/break.mcfunction
@@ -3,8 +3,6 @@ playsound minecraft:block.beacon.deactivate master @a ~ ~ ~ 1 0.65
 particle minecraft:block redstone_block ~ ~1 ~ 0.2 0.4 0.2 1.5 50 force @a
 
 
-scoreboard players operation #129- stockcounter = @s stockcounter
-
 execute if entity @e[tag=129-totem-using,scores={counter=1..},limit=1] as @e[tag=129-totem-using,scores={counter=1..}] if score @s stockcounter = #129- stockcounter run tag @s add 129-totem-now
 
 execute if entity @e[tag=129-totem-now,limit=1] as @e[tag=129-totem-now] run function project-c:jobaction/129/skill/2/totem/timeover
@@ -15,3 +13,6 @@ execute if entity @e[tag=129-totem-now,limit=1] as @e[tag=129-totem-now] run tag
 
 
 function project-c:jobaction/129/skill/2/totem/remove-together
+
+
+scoreboard players reset #129-

--- a/data/project-c/functions/jobaction/129/skill/2/totem/end-check.mcfunction
+++ b/data/project-c/functions/jobaction/129/skill/2/totem/end-check.mcfunction
@@ -1,6 +1,4 @@
 
-scoreboard players operation #129- stockcounter = @s stockcounter
-
 execute if entity @e[tag=129-totem-using,scores={counter=1..},limit=1] as @e[tag=129-totem-using,scores={counter=1..}] if score @s stockcounter = #129- stockcounter run tag @s add 129-totem-now
 
 execute unless entity @e[tag=129-totem-now,limit=1] run function project-c:jobaction/129/skill/2/totem/end

--- a/data/project-c/functions/jobaction/129/skill/2/totem/particle.mcfunction
+++ b/data/project-c/functions/jobaction/129/skill/2/totem/particle.mcfunction
@@ -6,5 +6,5 @@ particle dust 0.7 0 0 0.3 ~ ~ ~ 0 0 0 0 1 force
 
 execute if score @s counter matches 1..10 positioned ^ ^ ^0.115 run function project-c:jobaction/129/skill/2/totem/particle
 execute if score @s counter matches 11 rotated ~180 ~ positioned ^ ^ ^0.115 run function project-c:jobaction/129/skill/2/totem/particle
-execute if score @s counter matches 12..20 positioned ^ ^ ^0.115 run function project-c:jobaction/129/skill/2/totem/particle
-execute if score @s counter matches 11.. run scoreboard players reset @s
+execute if score @s counter matches 12..15 positioned ^ ^ ^0.115 run function project-c:jobaction/129/skill/2/totem/particle
+execute if score @s counter matches 15.. run scoreboard players reset @s

--- a/data/project-c/functions/jobaction/129/skill/2/totem/remove-together.mcfunction
+++ b/data/project-c/functions/jobaction/129/skill/2/totem/remove-together.mcfunction
@@ -1,10 +1,11 @@
 scoreboard players operation #129- stockcounter = @s stockcounter
 scoreboard players operation #129- playerNumber = @s playerNumber
 execute if entity @e[tag=129-totem-using,limit=1] as @e[tag=129-totem-using] if score @s stockcounter = #129- stockcounter run tag @s add kill
-execute if entity @e[tag=129-totem-skull,limit=1] as @e[tag=129-totem-skull] if score @s stockcounter = #129- stockcounter run tag @s add kill
-execute if entity @e[tag=129-totem,limit=1] as @e[tag=129-totem] if score @s stockcounter = #129- stockcounter run tag @s add kill
+execute if entity @e[tag=129-totemA,limit=1] as @e[tag=129-totemA] if score @s stockcounter = #129- stockcounter run tag @s add kill
 tag @s add kill
+execute as @e[tag=kill] run kill @s
 
+scoreboard players set @s counter 1000000
 
 execute as @a if score @s playerNumber = #129- playerNumber run tag @s add 129-2-end-owner
 #アイテムデータに記述してるクールタイムを取得してプレイヤーに渡す
@@ -17,8 +18,3 @@ execute as @a[tag=129-2-end-owner] run tag @s remove SkillReady2
 execute as @a[tag=129-2-end-owner] run scoreboard players set @s usedSkill 2
 execute as @a[tag=129-2-end-owner] run tag @s remove 129-2-end-owner
 
-execute as @e[tag=kill] run kill @s
-
-scoreboard players set @s counter 1000000
-
-scoreboard players reset #129-

--- a/data/project-c/functions/jobaction/129/skill/2/totem/replace-villager.mcfunction
+++ b/data/project-c/functions/jobaction/129/skill/2/totem/replace-villager.mcfunction
@@ -1,0 +1,38 @@
+scoreboard players operation #129- playerNumber = @s playerNumber
+scoreboard players operation #129- teamNumber = @s teamNumber
+scoreboard players operation #129- stockcounter = @s stockcounter
+scoreboard players operation #129- HarfHP = @s HarfHP
+scoreboard players remove #129- HarfHP 10
+
+#アマスタに記憶してる効果時間を取得
+scoreboard players operation #129- counter = @s counter
+
+summon armor_stand ~ ~ ~ {Tags:["129-totem","129-totem-ArV","129-totemA","this2","this2-"],Small:1b,Marker:1b,Invisible:1b,NoBasePlate:1b,Passengers:[{id:"minecraft:villager",Silent:1b,NoAI:1b,Health:1000f,Tags:["129-totemV","129-totem-ArV","129-totemA","this2-","this2-V","Battle"],ActiveEffects:[{Id:14b,Amplifier:0b,Duration:1000000,ShowParticles:0b}],Attributes:[{Name:"generic.max_health",Base:1000}],VillagerData:{profession:"minecraft:none"}}]}
+
+tag @s add 129-totem-ArV-R-me
+execute at @e[tag=129-totem-ArV-R-me] run tp @e[tag=this2] ~ ~ ~ ~ ~
+
+execute as @e[type=witch,distance=..0] run tag @s add 129-kill-witch
+execute as @e[tag=129-kill-witch] at @s run tp @s ~ -20 ~
+execute as @e[tag=129-kill-witch] run kill @s
+
+#前のコアを消す処理
+execute as @e[tag=129-totem] if score @s playerNumber = #129- playerNumber run scoreboard players add #129- subcounter 1
+execute if score #129- subcounter matches 1.. as @e[tag=129-totem-ArV] if score @s playerNumber = #129- playerNumber run kill @s
+
+
+scoreboard players operation @e[tag=this2-] playerNumber = #129- playerNumber
+execute if score #129- teamNumber matches 1 run team join RedDummy @e[tag=this2-V]
+execute if score #129- teamNumber matches 2 run team join BlueDummy @e[tag=this2-V]
+scoreboard players operation @e[tag=this2-] teamNumber = #129- teamNumber
+execute as @e[tag=this2-V] store result entity @s Health double 0.1 run scoreboard players get #129- HarfHP
+scoreboard players operation @e[tag=this2] HarfHP = #129- HarfHP
+scoreboard players operation @e[tag=this2] counter = #129- counter
+
+scoreboard players operation @e[tag=this2-] stockcounter = #129- stockcounter
+
+tag @e[tag=this2] remove this2
+tag @e[tag=this2-] remove this2-
+tag @e[tag=this2-V] remove this2-V
+
+tag @s remove 129-totem-ArV-R-me

--- a/data/project-c/functions/jobaction/129/skill/2/totem/set.mcfunction
+++ b/data/project-c/functions/jobaction/129/skill/2/totem/set.mcfunction
@@ -13,14 +13,15 @@ execute store result score #129- counter run data get block 0 0 0 Items[{Slot:0b
 scoreboard players operation #129- counter *= #20 counter
 
 #summon minecraft:shulker ~ ~ ~ {Color:0b,Silent:1b,NoAI:1b,Tags:["this2","129-totem","Battle"],Health:6f,Attributes:[{Name:"generic.max_health",Base:6d},{Name:"generic.armor",Base:20d},{Name:"generic.armor_toughness",Base:20d}],ActiveEffects:[{Id:13b,Amplifier:0b,Duration:2147483647,ShowParticles:0b}]}
-summon villager ~ ~ ~ {Tags:["129-totem","this2","this2-","Battle"],ActiveEffects:[{Id:14b,Amplifier:0b,Duration:1000000,ShowParticles:0b}],Silent:1b,NoAI:1b,VillagerData:{profession:"minecraft:none"},Health:1000f,Attributes:[{Name:generic.max_health,Base:1000}]}
-execute rotated 0 0 positioned ^ ^ ^0.7 facing entity @e[tag=this2,limit=1] feet positioned ^-0.15 ^ ^ run summon armor_stand ~ ~0.5 ~ {Tags:["this2-","129-totem-skull","129-ts1"],Rotation:[183F,0F],Small:1b,Marker:1b,Invisible:1b,NoBasePlate:1b,Pose:{Body:[0f,0f,0f],LeftArm:[0f,0f,0f],RightArm:[-45f,0f,0f],LeftLeg:[0f,0f,0f],RightLeg:[0f,0f,0f],Head:[0f,0f,0f]},HandItems:[{id:"minecraft:skeleton_skull",Count:1b},{}]}
-execute rotated 90 0 positioned ^ ^ ^0.7 facing entity @e[tag=this2,limit=1] feet positioned ^-0.15 ^ ^ run summon armor_stand ~ ~0.5 ~ {Tags:["this2-","129-totem-skull","129-ts2"],Rotation:[273F,0F],Small:1b,Marker:1b,Invisible:1b,NoBasePlate:1b,Pose:{Body:[0f,0f,0f],LeftArm:[0f,0f,0f],RightArm:[-45f,0f,0f],LeftLeg:[0f,0f,0f],RightLeg:[0f,0f,0f],Head:[0f,0f,0f]},HandItems:[{id:"minecraft:skeleton_skull",Count:1b},{}]}
-execute rotated 180 0 positioned ^ ^ ^0.7 facing entity @e[tag=this2,limit=1] feet positioned ^-0.15 ^ ^ run summon armor_stand ~ ~0.5 ~ {Tags:["this2-","129-totem-skull","129-ts3"],Rotation:[3F,0F],Small:1b,Marker:1b,Invisible:1b,NoBasePlate:1b,Pose:{Body:[0f,0f,0f],LeftArm:[0f,0f,0f],RightArm:[-45f,0f,0f],LeftLeg:[0f,0f,0f],RightLeg:[0f,0f,0f],Head:[0f,0f,0f]},HandItems:[{id:"minecraft:skeleton_skull",Count:1b},{}]}
-execute rotated 270 0 positioned ^ ^ ^0.7 facing entity @e[tag=this2,limit=1] feet positioned ^-0.15 ^ ^ run summon armor_stand ~ ~0.5 ~ {Tags:["this2-","129-totem-skull","129-ts4"],Rotation:[93F,0F],Small:1b,Marker:1b,Invisible:1b,NoBasePlate:1b,Pose:{Body:[0f,0f,0f],LeftArm:[0f,0f,0f],RightArm:[-45f,0f,0f],LeftLeg:[0f,0f,0f],RightLeg:[0f,0f,0f],Head:[0f,0f,0f]},HandItems:[{id:"minecraft:skeleton_skull",Count:1b},{}]}
+#summon villager ~ ~ ~ {Tags:["129-totem","this2","this2-0","this2-","Battle"],ActiveEffects:[{Id:14b,Amplifier:0b,Duration:1000000,ShowParticles:0b}],Silent:1b,NoAI:1b,VillagerData:{profession:"minecraft:none"},Health:1000f,Attributes:[{Name:generic.max_health,Base:1000}]}
+summon armor_stand ~ ~ ~ {Tags:["129-totem","129-totem-ArV","129-totemA","this2","this2-"],Small:1b,Marker:1b,Invisible:1b,NoBasePlate:1b,Passengers:[{id:"minecraft:villager",Silent:1b,NoAI:1b,Health:1000f,Tags:["129-totemV","129-totem-ArV","129-totemA","this2-","this2-V","Battle"],ActiveEffects:[{Id:14b,Amplifier:0b,Duration:1000000,ShowParticles:0b}],Attributes:[{Name:"generic.max_health",Base:1000}],VillagerData:{profession:"minecraft:none"}}]}
+execute rotated 0 0 positioned ^ ^ ^0.7 facing entity @e[tag=this2,limit=1] feet positioned ^-0.15 ^ ^ run summon armor_stand ~ ~0.5 ~ {Tags:["129-totemA","this2-","129-totem-skull","129-ts1"],Rotation:[183F,0F],Small:1b,Marker:1b,Invisible:1b,NoBasePlate:1b,Pose:{Body:[0f,0f,0f],LeftArm:[0f,0f,0f],RightArm:[-45f,0f,0f],LeftLeg:[0f,0f,0f],RightLeg:[0f,0f,0f],Head:[0f,0f,0f]},HandItems:[{id:"minecraft:skeleton_skull",Count:1b},{}]}
+execute rotated 90 0 positioned ^ ^ ^0.7 facing entity @e[tag=this2,limit=1] feet positioned ^-0.15 ^ ^ run summon armor_stand ~ ~0.5 ~ {Tags:["129-totemA","this2-","129-totem-skull","129-ts2"],Rotation:[273F,0F],Small:1b,Marker:1b,Invisible:1b,NoBasePlate:1b,Pose:{Body:[0f,0f,0f],LeftArm:[0f,0f,0f],RightArm:[-45f,0f,0f],LeftLeg:[0f,0f,0f],RightLeg:[0f,0f,0f],Head:[0f,0f,0f]},HandItems:[{id:"minecraft:skeleton_skull",Count:1b},{}]}
+execute rotated 180 0 positioned ^ ^ ^0.7 facing entity @e[tag=this2,limit=1] feet positioned ^-0.15 ^ ^ run summon armor_stand ~ ~0.5 ~ {Tags:["129-totemA","this2-","129-totem-skull","129-ts3"],Rotation:[3F,0F],Small:1b,Marker:1b,Invisible:1b,NoBasePlate:1b,Pose:{Body:[0f,0f,0f],LeftArm:[0f,0f,0f],RightArm:[-45f,0f,0f],LeftLeg:[0f,0f,0f],RightLeg:[0f,0f,0f],Head:[0f,0f,0f]},HandItems:[{id:"minecraft:skeleton_skull",Count:1b},{}]}
+execute rotated 270 0 positioned ^ ^ ^0.7 facing entity @e[tag=this2,limit=1] feet positioned ^-0.15 ^ ^ run summon armor_stand ~ ~0.5 ~ {Tags:["129-totemA","this2-","129-totem-skull","129-ts4"],Rotation:[93F,0F],Small:1b,Marker:1b,Invisible:1b,NoBasePlate:1b,Pose:{Body:[0f,0f,0f],LeftArm:[0f,0f,0f],RightArm:[-45f,0f,0f],LeftLeg:[0f,0f,0f],RightLeg:[0f,0f,0f],Head:[0f,0f,0f]},HandItems:[{id:"minecraft:skeleton_skull",Count:1b},{}]}
 scoreboard players operation @e[tag=this2-] playerNumber = @s playerNumber
-execute if entity @s[team=Red] run team join RedDummy @e[tag=this2]
-execute if entity @s[team=Blue] run team join BlueDummy @e[tag=this2]
+execute if entity @s[team=Red] run team join RedDummy @e[tag=this2-V]
+execute if entity @s[team=Blue] run team join BlueDummy @e[tag=this2-V]
 scoreboard players operation @e[tag=this2-] teamNumber = @s teamNumber
 scoreboard players set @e[tag=this2] HarfHP 10000
 scoreboard players operation @e[tag=this2] counter = #129- counter
@@ -31,6 +32,7 @@ scoreboard players operation @e[tag=this2-] stockcounter = @e[tag=this2] stockco
 
 tag @e[tag=this2] remove this2
 tag @e[tag=this2-] remove this2-
+tag @e[tag=this2-V] remove this2-V
 
 data merge block -86 61 -11 {auto:1b}
 

--- a/data/project-c/loot_tables/neac/129/2.json
+++ b/data/project-c/loot_tables/neac/129/2.json
@@ -17,14 +17,14 @@
             {
               "function": "minecraft:set_lore",
               "lore": [
-                [{"text":"右クリック","italic":false,"color":"yellow"},{"text":" / ","color":"gray"},{"text":"CT:30s","italic":false,"color":"green"}],
+                [{"text":"右クリック","italic":false,"color":"yellow"},{"text":" / ","color":"gray"},{"text":"展開終了時CT:30s","italic":false,"color":"green"}],
                 {"text": "視点先に破壊可能なデストーテムを設置する。","italic": false,"color": "white"},
                 {"text": "トーテムを右クリックでデスプロテクション状態になる。","italic": false,"color": "white"},
                 {"text": "トーテムは一定時間後、使用者がいなければ破壊される。","italic": false,"color": "white"},
                 {"text": ""},
                 {"text": "-- デスプロテクション --","italic": false,"color": "yellow"},
                 {"text": "体力が半分より多い時に使用可能。","italic": false,"color": "white"},
-                {"text": "15秒の間、金ハート10個状態になる。","italic": false,"color": "white"},
+                {"text": "25秒の間、金ハート10個状態になる。","italic": false,"color": "white"},
                 {"text": "金ハート消失時、使用開始時の体力が75%以上であれば75%、","italic": false,"color": "white"},
                 {"text": "それ以下であればその体力で使用開始位置に戻る。","italic": false,"color": "white"},
                 {"text": "効果時間が終了すると、","italic": false,"color": "white"},
@@ -33,7 +33,7 @@
             },
             {
               "function": "minecraft:set_nbt",
-              "tag": "{HideFlags:63,129--:2b,cooltime:30,e-time:20,e-time2:15,Enchantments:[{}]}"
+              "tag": "{HideFlags:63,129--:2b,cooltime:30,e-time:30,e-time2:25,Enchantments:[{}]}"
             }
           ]
         }


### PR DESCRIPTION
効果時間の延長(展開30秒、効果25秒)
アマスタ基準に変更(村人が雷に打たれると壊れるため)
--体力スコアはアマスタに保持するように変更
説明文のCT部分を変更(壊されてからCTになる説明に変更)
村人が検知できなくなったときに近く(distance=..0)のウィッチをkillするように変更