### PR TITLE
裏中華リメイク/スカイルーイン落下ダメ無効化

### DIFF
--- a/data/project-c/functions/stage/gimmick/-chinatown.mcfunction
+++ b/data/project-c/functions/stage/gimmick/-chinatown.mcfunction
@@ -1,4 +1,56 @@
-execute positioned 976 68 -1000 if entity @a[distance=..150,gamemode=!spectator] as @a[distance=..150,gamemode=!spectator] at @s if block ~ ~-0.1 ~ minecraft:purple_glazed_terracotta run scoreboard players add @s Chinacount 1
-execute if entity @a[scores={Chinacount=1}] as @a[scores={Chinacount=1}] run effect give @s minecraft:poison 1 1 false
-execute if entity @a[scores={Chinacount=10}] as @a[scores={Chinacount=10}] run scoreboard players reset @s Chinacount
-execute if entity @a[scores={Chinacount=1..}] as @a[scores={Chinacount=1..}] at @s unless block ~ ~-1 ~ minecraft:purple_glazed_terracotta run scoreboard players reset @s Chinacount
+#region テレポーターのパーティクル
+particle minecraft:happy_villager 923 110 -1005 0.25 0.5 0.25 1 1 normal
+particle minecraft:happy_villager 923 110 -1002 0.25 0.5 0.25 1 1 normal
+particle minecraft:happy_villager 923 110 -998 0.25 0.5 0.25 1 1 normal
+particle minecraft:happy_villager 923 110 -995 0.25 0.5 0.25 1 1 normal
+
+particle minecraft:happy_villager 1029 110 -995 0.25 0.5 0.25 1 1 normal
+particle minecraft:happy_villager 1029 110 -998 0.25 0.5 0.25 1 1 normal
+particle minecraft:happy_villager 1029 110 -1002 0.25 0.5 0.25 1 1 normal
+particle minecraft:happy_villager 1029 110 -1005 0.25 0.5 0.25 1 1 normal
+
+particle dust 1 0 0 1 961 70.5 -1045 0.25 0.75 0.25 1 3 force
+particle minecraft:dust 1 0.5 0 1 930 77.5 -1009 0.25 0.75 0.25 1 3 force
+particle minecraft:dust 1 1 0 1 960 86.5 -1007 0.25 0.75 0.25 1 3 force
+
+particle dust 1 0 0 1 982 87.5 -1038 0.25 0.75 0.25 1 3 force
+particle dust 0 1 0 1 1015 70.5 -1032 0.25 0.75 0.25 1 3 force
+particle dust 0 1 1 1 1006 81.5 -1010 0.25 0.75 0.25 1 3 force
+
+particle dust 0 1 1 1 1008 85.5 -991 0.25 0.75 0.25 1 3 force
+particle dust 1 1 0 1 1002 70.5 -978 0.25 0.75 0.25 1 3 force
+particle dust 0 0 1 1 998 97.5 -961 0.25 0.75 0.25 1 3 force
+
+particle dust 0 1 0 1 969 87.5 -954 0.25 0.75 0.25 1 3 force
+particle dust 1 0.5 0 1 965 81.5 -991 0.25 0.75 0.25 1 3 force
+particle dust 0 0 1 1 932 70.5 -989 0.25 0.75 0.25 1 3 force
+
+#endregion
+
+# テレポート
+execute positioned 923 109.5 -1005 if entity @a[distance=..0.5,gamemode=!spectator,limit=1] run tp @a[distance=..0.5,gamemode=!spectator] 1005 78.5 -1047 0 0
+execute positioned 923 109.5 -1002 if entity @a[distance=..0.5,gamemode=!spectator,limit=1] run tp @a[distance=..0.5,gamemode=!spectator] 939 78.5 -1043 -45 0
+execute positioned 923 109.5 -998 if entity @a[distance=..0.5,gamemode=!spectator,limit=1] run tp @a[distance=..0.5,gamemode=!spectator] 939 79.5 -993 -45 0
+execute positioned 923 109.5 -995 if entity @a[distance=..0.5,gamemode=!spectator,limit=1] run tp @a[distance=..0.5,gamemode=!spectator] 995 79.5 -984 145 0
+
+execute positioned 1029 109.5 -995 if entity @a[distance=..0.5,gamemode=!spectator,limit=1] run tp @a[distance=..0.5,gamemode=!spectator] 947 76.5 -953 180 0
+execute positioned 1029 109.5 -998 if entity @a[distance=..0.5,gamemode=!spectator,limit=1] run tp @a[distance=..0.5,gamemode=!spectator] 1021 77.5 -973 90 -10
+execute positioned 1029 109.5 -1002 if entity @a[distance=..0.5,gamemode=!spectator,limit=1] run tp @a[distance=..0.5,gamemode=!spectator] 1022 77.5 -1010 135 0
+execute positioned 1029 109.5 -1005 if entity @a[distance=..0.5,gamemode=!spectator,limit=1] run tp @a[distance=..0.5,gamemode=!spectator] 948 78.5 -1008 180 0
+
+
+execute positioned 961 69.5 -1045 if entity @a[distance=..0.5,gamemode=!spectator,limit=1] run tp @a[distance=..0.5,gamemode=!spectator] 983.0 85.5 -1041.0 -90 0
+execute positioned 930 76.5 -1009 if entity @a[distance=..0.5,gamemode=!spectator,limit=1] run tp @a[distance=..0.5,gamemode=!spectator] 963 80.5 -991 45 0
+execute positioned 960 85.5 -1007 if entity @a[distance=..0.5,gamemode=!spectator,limit=1] run tp @a[distance=..0.5,gamemode=!spectator] 1002 69.5 -980 135 0
+
+execute positioned 982 86.5 -1038 if entity @a[distance=..0.5,gamemode=!spectator,limit=1] run tp @a[distance=..0.5,gamemode=!spectator] 961 69.5 -1043 0 0
+execute positioned 1015 69.5 -1032 if entity @a[distance=..0.5,gamemode=!spectator,limit=1] run tp @a[distance=..0.5,gamemode=!spectator] 971.0 86 -958.0 135 0
+execute positioned 1006 80.5 -1010 if entity @a[distance=..0.5,gamemode=!spectator,limit=1] run tp @a[distance=..0.5,gamemode=!spectator] 1010 84.5 -989 0 0
+
+execute positioned 1008 84.5 -991 if entity @a[distance=..0.5,gamemode=!spectator,limit=1] run tp @a[distance=..0.5,gamemode=!spectator] 1006 83.5 -1014 180 0
+execute positioned 1002 69.5 -978 if entity @a[distance=..0.5,gamemode=!spectator,limit=1] run tp @a[distance=..0.5,gamemode=!spectator] 958 85.5 -1009 135 0
+execute positioned 998 96.5 -961 if entity @a[distance=..0.5,gamemode=!spectator,limit=1] run tp @a[distance=..0.5,gamemode=!spectator] 935 69.5 -989 -45 0
+
+execute positioned 969 86.5 -954 if entity @a[distance=..0.5,gamemode=!spectator,limit=1] run tp @a[distance=..0.5,gamemode=!spectator] 1017 69.5 -1033 45 0
+execute positioned 965 80.5 -991 if entity @a[distance=..0.5,gamemode=!spectator,limit=1] run tp @a[distance=..0.5,gamemode=!spectator] 930 76.5 -1011 -90 0
+execute positioned 932 69.5 -989 if entity @a[distance=..0.5,gamemode=!spectator,limit=1] run tp @a[distance=..0.5,gamemode=!spectator] 999 96.5 -963 180 0

--- a/data/project-c/functions/stage/gimmick/skyruin.mcfunction
+++ b/data/project-c/functions/stage/gimmick/skyruin.mcfunction
@@ -1,5 +1,5 @@
 execute as @a[x=-486,y=66,z=5,distance=..150,gamemode=!spectator] at @s if block ~ ~-1 ~ minecraft:dark_prismarine run tag @s add SkyRuinGimmick
 execute if entity @a[tag=SkyRuinGimmick] as @a[tag=SkyRuinGimmick] run effect give @s minecraft:levitation 1 25
-execute if entity @a[tag=SkyRuinGimmick] as @a[tag=SkyRuinGimmick] run effect give @s minecraft:jump_boost 5 255
+#execute if entity @a[tag=SkyRuinGimmick] as @a[tag=SkyRuinGimmick] run effect give @s minecraft:jump_boost 5 255
 execute if entity @a[tag=SkyRuinGimmick] as @a[tag=SkyRuinGimmick] run effect give @s minecraft:speed 1 120
 execute if entity @a[tag=SkyRuinGimmick] as @a[tag=SkyRuinGimmick] run tag @s remove SkyRuinGimmick

--- a/data/project-c/functions/stage/selectstagestart/44.mcfunction
+++ b/data/project-c/functions/stage/selectstagestart/44.mcfunction
@@ -1,3 +1,3 @@
-fill 1015 84 -955 1011 88 -959 minecraft:air
-fill 939 78 -1046 943 82 -1042 minecraft:air
+fill 922 109 -1006 924 110 -994 minecraft:structure_void replace red_stained_glass
+fill 1030 109 -994 1028 110 -1006 minecraft:structure_void replace blue_stained_glass
 data merge entity @e[tag=ItemSpawnerCart,limit=1] {SpawnRange:80}

--- a/data/project-c/functions/stage/selectstagesystem/22.mcfunction
+++ b/data/project-c/functions/stage/selectstagesystem/22.mcfunction
@@ -6,3 +6,5 @@ fill -482 66 28 -488 72 34 minecraft:red_stained_glass hollow
 fill -439 59 -16 -433 65 -10 minecraft:blue_stained_glass hollow
 data merge block -111 47 -122 {auto:1b}
 execute if score #MenuSpawnItem counter matches 1 run summon minecraft:armor_stand -482 25 13 {NoGravity:1b,Silent:1b,Invisible:1b,Invulnerable:1b,Small:1b,Tags:["ItemSpawnerPosition","Stable"],Marker:1b,NoBasePlate:1b,DisabledSlots:2039583}
+
+gamerule fallDamage false

--- a/data/project-c/functions/stage/selectstagesystem/44.mcfunction
+++ b/data/project-c/functions/stage/selectstagesystem/44.mcfunction
@@ -1,8 +1,10 @@
-tp @a[team=Red] 1013 86 -957 135 0
-tp @a[team=Blue] 941 80 -1044 -45 0
+tp @a[team=Red] 917 110 -1000 -90 0
+tp @a[team=Blue] 1035 110 -1000 90 0
 tp @a[team=] 976 90 -1038 0 15
 execute as @a at @s run spawnpoint @s
-fill 1015 84 -955 1011 88 -959 minecraft:red_stained_glass hollow
-fill 939 78 -1046 943 82 -1042 minecraft:blue_stained_glass hollow
+fill 922 109 -1006 924 110 -994 minecraft:red_stained_glass replace structure_void
+fill 1030 109 -994 1028 110 -1006 minecraft:blue_stained_glass replace structure_void
 data merge block -111 47 -122 {auto:1b}
 execute if score #MenuSpawnItem counter matches 1 run summon minecraft:armor_stand 977 45 -1000 {NoGravity:1b,Silent:1b,Invisible:1b,Invulnerable:1b,Small:1b,Tags:["ItemSpawnerPosition","Stable"],Marker:1b,NoBasePlate:1b,DisabledSlots:2039583}
+
+gamerule fallDamage false


### PR DESCRIPTION
ワールドに落下ダメージ無効化ゲームルールを解除するコマブロがあるので併用しないとバグる